### PR TITLE
refactor: Move DomainUrl et al to ontol-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3830,12 +3830,14 @@ name = "ontol-core"
 version = "0.1.0"
 dependencies = [
  "arcstr",
+ "async-trait",
  "bit-vec",
  "compact_str",
  "ontol-macros",
  "pretty_assertions",
  "serde",
  "thin-vec",
+ "url",
 ]
 
 [[package]]
@@ -3857,7 +3859,7 @@ name = "ontol-examples"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "ontol-compiler",
+ "ontol-core",
  "url",
 ]
 
@@ -3898,6 +3900,7 @@ dependencies = [
  "indoc",
  "lazy-regex",
  "ontol-compiler",
+ "ontol-core",
  "ontol-parser",
  "ontol-runtime",
  "serde",
@@ -3997,6 +4000,7 @@ dependencies = [
  "fnv",
  "jsonschema",
  "ontol-compiler",
+ "ontol-core",
  "ontol-faker",
  "ontol-parser",
  "ontol-runtime",
@@ -4034,6 +4038,7 @@ dependencies = [
  "juniper_axum",
  "notify-debouncer-full",
  "ontol-compiler",
+ "ontol-core",
  "ontol-examples",
  "ontol-lsp",
  "ontol-parser",

--- a/ontol/ontol-compiler/src/error.rs
+++ b/ontol/ontol-compiler/src/error.rs
@@ -1,8 +1,9 @@
 use std::fmt::Debug;
 
+use ontol_core::url::DomainUrl;
 use ontol_runtime::format_utils::CommaSeparated;
 
-use crate::{source::SourceSpan, topology::DomainUrl};
+use crate::source::SourceSpan;
 
 pub struct UnifiedCompileError {
     pub errors: Vec<SpannedCompileError>,

--- a/ontol/ontol-compiler/src/lib.rs
+++ b/ontol/ontol-compiler/src/lib.rs
@@ -6,6 +6,7 @@ pub use error::*;
 use fnv::{FnvHashMap, FnvHashSet};
 use lowering::context::LoweringOutcome;
 use misc::MiscCtx;
+use ontol_core::url::DomainUrl;
 use primitive::init_ontol_primitives;
 use properties::PropCtx;
 use std::{
@@ -34,7 +35,7 @@ pub use source::*;
 use strings::StringCtx;
 use text_patterns::{TextPatterns, compile_all_text_patterns};
 use thesaurus::Thesaurus;
-use topology::{DomainTopology, DomainUrl, LoadedDomains};
+use topology::{DomainTopology, LoadedDomains};
 use tracing::debug;
 use type_check::seal::SealCtx;
 use types::{DefTypeCtx, TypeCtx};

--- a/ontol/ontol-compiler/src/lowering/context.rs
+++ b/ontol/ontol-compiler/src/lowering/context.rs
@@ -8,6 +8,7 @@ use std::{
 use arcstr::ArcStr;
 use fnv::FnvHashMap;
 use indexmap::map::Entry;
+use ontol_core::url::{DomainUrl, DomainUrlParser};
 use ontol_parser::{
     ParserError, U32Span,
     cst::view::{NodeView, TokenView},
@@ -27,7 +28,6 @@ use crate::{
     ontol_syntax::OntolHeaderData,
     pattern::{Pattern, PatternKind},
     relation::{DefRelTag, RelId, RelParams, Relationship},
-    topology::{DomainUrl, DomainUrlParser},
 };
 
 pub struct LoweringCtx<'c, 'm> {

--- a/ontol/ontol-compiler/src/lowering/lower_ontol.rs
+++ b/ontol/ontol-compiler/src/lowering/lower_ontol.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
+use ontol_core::url::DomainUrl;
 use ontol_parser::cst::{
     inspect::{self as insp},
     view::{NodeView, TokenView},
@@ -12,7 +13,6 @@ use crate::{
     edge::{CardinalKind, EdgeId},
     namespace::{DocId, Space},
     ontol_syntax::{OntolHeaderData, WithDocs, extract_domain_headerdata},
-    topology::DomainUrl,
 };
 
 use super::{

--- a/ontol/ontol-compiler/src/ontol_syntax.rs
+++ b/ontol/ontol-compiler/src/ontol_syntax.rs
@@ -1,5 +1,6 @@
 use std::{panic::UnwindSafe, str::FromStr, sync::Arc};
 
+use ontol_core::url::{DomainUrl, DomainUrlParser};
 use ontol_macros::test;
 use ontol_parser::{
     ParserError, U32Span,
@@ -16,11 +17,7 @@ use ontol_runtime::{DefId, ontology::domain::DomainId};
 use tracing::info;
 use ulid::Ulid;
 
-use crate::{
-    CompileError, Session, Src, lower_ontol_syntax,
-    lowering::context::LoweringOutcome,
-    topology::{DomainUrl, DomainUrlParser},
-};
+use crate::{CompileError, Session, Src, lower_ontol_syntax, lowering::context::LoweringOutcome};
 
 /// A generalization of an ONTOL source file.
 ///

--- a/ontol/ontol-compiler/src/source.rs
+++ b/ontol/ontol-compiler/src/source.rs
@@ -1,10 +1,9 @@
 use std::{fmt::Debug, ops::Deref, sync::Arc};
 
 use fnv::FnvHashMap;
+use ontol_core::url::DomainUrl;
 use ontol_parser::U32Span;
 use ontol_runtime::DomainIndex;
-
-use crate::topology::DomainUrl;
 
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct SourceId(pub u32);

--- a/ontol/ontol-core/Cargo.toml
+++ b/ontol/ontol-core/Cargo.toml
@@ -13,10 +13,12 @@ doctest = false
 [dependencies]
 ontol-macros.path = "../ontol-macros"
 arcstr.workspace = true
+async-trait = "0.1"
 bit-vec = { version = "0.8", features = ["serde"] }
 compact_str = { version = "0.8", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 thin-vec.workspace = true
+url = "2"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/ontol/ontol-core/src/lib.rs
+++ b/ontol/ontol-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod debug;
 pub mod property;
 pub mod rustdoc;
+pub mod url;
 
 extern crate self as ontol_core;

--- a/ontol/ontol-core/src/url.rs
+++ b/ontol/ontol-core/src/url.rs
@@ -1,0 +1,118 @@
+use std::{fmt::Display, sync::Arc};
+
+use url::Url;
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct DomainUrl(Url);
+
+#[async_trait::async_trait]
+pub trait DomainUrlResolver: Send + Sync {
+    async fn resolve_domain_url(&self, url: &DomainUrl) -> Option<Arc<String>>;
+}
+
+pub struct DomainUrlParser {
+    base_url: url::Url,
+}
+
+pub enum DomainUrlError {
+    InvalidDomainReference,
+}
+
+impl DomainUrl {
+    pub fn new(url: Url) -> Self {
+        Self(url)
+    }
+
+    pub fn parse(name: &str) -> Self {
+        DomainUrlParser::default()
+            .parse(name)
+            .unwrap_or_else(|_| panic!())
+    }
+
+    pub fn short_name(&self) -> &str {
+        if let Some(segments) = self.0.path_segments() {
+            if let Some(last) = segments.last() {
+                return last;
+            }
+        }
+
+        "<none>"
+    }
+
+    pub fn url(&self) -> &Url {
+        &self.0
+    }
+
+    pub fn join(&self, other: &DomainUrl) -> Self {
+        match other.0.scheme() {
+            "file" => {
+                let mut next_url = self.0.clone();
+
+                {
+                    let mut segments = next_url.path_segments_mut().unwrap();
+
+                    segments.pop();
+
+                    if let Some(orig_segments) = other.0.path_segments() {
+                        if let Some(yo) = orig_segments.last() {
+                            segments.push(yo);
+                        }
+                    }
+                }
+
+                Self(next_url)
+            }
+            _ => other.clone(),
+        }
+    }
+}
+
+impl From<Url> for DomainUrl {
+    fn from(value: Url) -> Self {
+        Self(value)
+    }
+}
+
+impl From<DomainUrl> for Url {
+    fn from(value: DomainUrl) -> Self {
+        value.0
+    }
+}
+
+impl Display for DomainUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Default for DomainUrlParser {
+    fn default() -> Self {
+        Self {
+            base_url: url::Url::parse("file://").unwrap(),
+        }
+    }
+}
+
+impl DomainUrlParser {
+    pub fn parse(&self, uri: &str) -> Result<DomainUrl, DomainUrlError> {
+        let url = url::Url::options()
+            .base_url(Some(&self.base_url))
+            .parse(uri)
+            .map_err(|_| DomainUrlError::InvalidDomainReference)?;
+
+        Ok(DomainUrl(url))
+    }
+}
+
+#[async_trait::async_trait]
+impl DomainUrlResolver for Vec<Box<dyn DomainUrlResolver>> {
+    async fn resolve_domain_url(&self, url: &DomainUrl) -> Option<Arc<String>> {
+        for resolver in self.iter() {
+            if let Some(source) = resolver.resolve_domain_url(url).await {
+                return Some(source);
+            }
+        }
+
+        None
+    }
+}

--- a/ontol/ontol-examples/Cargo.toml
+++ b/ontol/ontol-examples/Cargo.toml
@@ -13,6 +13,6 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-ontol-compiler.path = "../ontol-compiler"
+ontol-core.path = "../ontol-core"
 async-trait.workspace = true
 url = "2"

--- a/ontol/ontol-examples/src/lib.rs
+++ b/ontol/ontol-examples/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use conduit::{blog_post_public, conduit_db};
-use ontol_compiler::topology::{DomainUrl, DomainUrlResolver};
+use ontol_core::url::{DomainUrl, DomainUrlResolver};
 use stix::stix_bundle;
 use url::Url;
 

--- a/ontol/ontol-lsp/Cargo.toml
+++ b/ontol/ontol-lsp/Cargo.toml
@@ -17,6 +17,7 @@ wasm = []
 [dependencies]
 ontol-runtime.path = "../ontol-runtime"
 ontol-compiler.path = "../ontol-compiler"
+ontol-core.path = "../ontol-core"
 ontol-parser.path = "../ontol-parser"
 serde.workspace = true
 serde_json.workspace = true

--- a/ontol/ontol-lsp/src/state.rs
+++ b/ontol/ontol-lsp/src/state.rs
@@ -2,13 +2,13 @@ use crate::docs::get_core_completions;
 use indoc::formatdoc;
 use lazy_regex::regex_replace_all;
 use ontol_compiler::ontol_syntax::{ArcString, OntolTreeSyntax};
-use ontol_compiler::topology::DomainUrl;
 use ontol_compiler::{
     CompileError, NO_SPAN, SourceId, SourceSpan, Sources,
     error::UnifiedCompileError,
     mem::Mem,
     topology::{DepGraphBuilder, GraphState, ParsedDomain},
 };
+use ontol_core::url::DomainUrl;
 use ontol_parser::ToUsizeRange;
 use ontol_parser::cst::inspect::{self as insp};
 use ontol_parser::cst::tree::{SyntaxNode, TreeNodeView, TreeTokenView};

--- a/ontol/ontol-test-utils/Cargo.toml
+++ b/ontol/ontol-test-utils/Cargo.toml
@@ -15,6 +15,7 @@ validate-jsonschema = ["dep:jsonschema"]
 
 [dependencies]
 ontol-compiler.path = "../ontol-compiler"
+ontol-core.path = "../ontol-core"
 ontol-parser.path = "../ontol-parser"
 ontol-runtime.path = "../ontol-runtime"
 ontol-faker.path = "../ontol-faker"

--- a/ontol/ontol-test-utils/src/lib.rs
+++ b/ontol/ontol-test-utils/src/lib.rs
@@ -9,8 +9,9 @@ use ontol_compiler::{
     error::UnifiedCompileError,
     mem::Mem,
     ontol_syntax::{ArcString, OntolTreeSyntax},
-    topology::{DepGraphBuilder, DomainTopology, DomainUrl, GraphState, ParsedDomain},
+    topology::{DepGraphBuilder, DomainTopology, GraphState, ParsedDomain},
 };
+use ontol_core::url::DomainUrl;
 use ontol_parser::cst_parse;
 use ontol_runtime::{
     DomainIndex, PropId,

--- a/ontool/Cargo.toml
+++ b/ontool/Cargo.toml
@@ -15,6 +15,7 @@ jemalloc = ["dep:tikv-jemallocator"]
 domain-engine-graphql.path = "../domain-engine/domain-engine-graphql"
 domain-engine-httpjson.path = "../domain-engine/domain-engine-httpjson"
 ontol-compiler.path = "../ontol/ontol-compiler"
+ontol-core.path = "../ontol/ontol-core"
 ontol-parser.path = "../ontol/ontol-parser"
 ontol-runtime.path = "../ontol/ontol-runtime"
 ontol-lsp.path = "../ontol/ontol-lsp"

--- a/ontool/benches/criterion_benches.rs
+++ b/ontool/benches/criterion_benches.rs
@@ -6,7 +6,7 @@ use domain_engine_graphql::domain::context::ServiceCtx;
 use domain_engine_store_inmemory::InMemoryConnection;
 use domain_engine_test_utils::graphql_test_utils::Exec;
 use indoc::indoc;
-use ontol_compiler::topology::DomainUrl;
+use ontol_core::url::DomainUrl;
 use ontol_examples::{
     AsAtlas,
     conduit::{blog_post_public, conduit_db, feed_public},

--- a/ontool/src/lib.rs
+++ b/ontool/src/lib.rs
@@ -14,12 +14,10 @@ use domain_engine_core::{DomainEngine, Session};
 use domain_engine_store_inmemory::InMemoryConnection;
 use notify_debouncer_full::{new_debouncer, notify::RecursiveMode};
 use ontol_compiler::{
-    SourceCodeRegistry, SourceId, Sources,
-    error::UnifiedCompileError,
-    mem::Mem,
+    SourceCodeRegistry, SourceId, Sources, error::UnifiedCompileError, mem::Mem,
     ontol_syntax::ArcString,
-    topology::{DomainUrl, DomainUrlParser, DomainUrlResolver},
 };
+use ontol_core::url::{DomainUrl, DomainUrlParser, DomainUrlResolver};
 use ontol_examples::FakeAtlasServer;
 use ontol_lsp::Backend;
 use ontol_runtime::{


### PR DESCRIPTION
can now get rid of ontol-examples dependency on ontol-compiler
