### PR TITLE
feat: Add a syntax node around modifiers

### DIFF
--- a/docs/src/interfaces.md
+++ b/docs/src/interfaces.md
@@ -203,7 +203,7 @@ def Book (
 
 def author_id (rel* is: serial)
 def Author (
-    rel. 'id'[rel* gen: auto]|id: author_id
+    rel. 'id'[rel* gen: auto]: author_id
     rel* 'name': text
     rel* 'books_written'?: {Book}
 )

--- a/ontol/ontol-compiler/src/lowering/lower_map.rs
+++ b/ontol/ontol-compiler/src/lowering/lower_map.rs
@@ -23,15 +23,16 @@ impl<V: NodeView> CstLowering<'_, '_, V> {
         let mut is_abstract = false;
 
         for modifier in stmt.modifiers() {
-            if modifier.slice() == "@abstract" {
+            let token = modifier.token()?;
+            if token.slice() == "@abstract" {
                 if matches!(block_context, BlockContext::SubDef(_)) {
                     CompileError::TODO("extern map cannot be abstract")
-                        .span_report(modifier.span(), &mut self.ctx);
+                        .span_report(token.span(), &mut self.ctx);
                 }
 
                 is_abstract = true;
             } else {
-                CompileError::InvalidModifier.span_report(modifier.span(), &mut self.ctx);
+                CompileError::InvalidModifier.span_report(token.span(), &mut self.ctx);
             }
         }
 

--- a/ontol/ontol-compiler/src/lowering/lower_ontol.rs
+++ b/ontol/ontol-compiler/src/lowering/lower_ontol.rs
@@ -341,29 +341,33 @@ impl<'c, 'm, V: NodeView> CstLowering<'c, 'm, V> {
 
     pub(super) fn read_def_modifiers(
         &mut self,
-        modifiers: impl Iterator<Item = V::Token>,
+        modifiers: impl Iterator<Item = insp::Modifier<V>>,
     ) -> DefModifiers {
         let mut m = DefModifiers::default();
 
         for modifier in modifiers {
-            match modifier.slice() {
+            let Some(token) = modifier.token() else {
+                continue;
+            };
+
+            match token.slice() {
                 "@private" => {
-                    m.private = Some(modifier.span());
+                    m.private = Some(token.span());
                 }
                 "@open" => {
-                    m.open = Some(modifier.span());
+                    m.open = Some(token.span());
                 }
                 "@extern" => {
-                    m.r#extern = Some(modifier.span());
+                    m.r#extern = Some(token.span());
                 }
                 "@macro" => {
-                    m.r#macro = Some(modifier.span());
+                    m.r#macro = Some(token.span());
                 }
                 "@crdt" => {
-                    m.crdt = Some(modifier.span());
+                    m.crdt = Some(token.span());
                 }
                 _ => {
-                    CompileError::InvalidModifier.span_report(modifier.span(), &mut self.ctx);
+                    CompileError::InvalidModifier.span_report(token.span(), &mut self.ctx);
                 }
             }
         }

--- a/ontol/ontol-compiler/src/ontol_syntax.rs
+++ b/ontol/ontol-compiler/src/ontol_syntax.rs
@@ -218,22 +218,13 @@ pub(crate) fn extract_domain_headerdata<V: NodeView>(
                         // TODO: check the subject
                         continue;
                     };
-                    let Some(relation_set) = rel_stmt.relation_set() else {
+                    let Some(relation) = rel_stmt.relation() else {
                         continue;
                     };
                     let Some(object) = rel_stmt.object() else {
                         continue;
                     };
 
-                    let relations: Vec<_> = relation_set.relations().collect();
-                    if relations.len() != 1 {
-                        errors.push((
-                            CompileError::TODO("one relation expected"),
-                            rel_stmt.view().span(),
-                        ));
-                        continue;
-                    }
-                    let relation = relations.into_iter().next().unwrap();
                     let Some(rel_q) = relation.relation_type() else {
                         continue;
                     };

--- a/ontol/ontol-compiler/test-cases/error/known_bugs/feature_request_readonly.on
+++ b/ontol/ontol-compiler/test-cases/error/known_bugs/feature_request_readonly.on
@@ -2,5 +2,5 @@ def foo (
     rel. 'id': (rel* is: text)
 
     // this is just a suggestion, but I think the `|` operator makes sense here
-    rel* 'readonly'|readonly: text // ERROR definition not found in this scope
+    rel* 'readonly'|readonly: text // ERROR parse error: expected `:`, found `|`
 )

--- a/ontol/ontol-compiler/test-cases/error/map/missing_attributes_in_match_is_ok.on
+++ b/ontol/ontol-compiler/test-cases/error/map/missing_attributes_in_match_is_ok.on
@@ -1,5 +1,11 @@
-def foo ( rel* 'a'|'b': text )
-def bar ( rel* 'c'|'d': text )
+def foo (
+    rel* 'a': text
+    rel* 'b': text
+)
+def bar (
+    rel* 'c': text
+    rel* 'd': text
+)
 map (
     @match foo( 'a': x ),
     bar( 'c': x ) // ERROR missing property `d`// NOTE consider using `match {}`

--- a/ontol/ontol-compiler/tests/compiler-integration/interface/json/test_serde.rs
+++ b/ontol/ontol-compiler/tests/compiler-integration/interface/json/test_serde.rs
@@ -543,22 +543,6 @@ fn test_string_default() {
 }
 
 #[test]
-fn test_prop_union() {
-    "
-    def vec3(
-        /// A vector component
-        rel* 'x'|'y'|'z': (
-            rel* is: i64
-        )
-    )
-    "
-    .compile_then(|test| {
-        let [vec3] = test.bind(["vec3"]);
-        assert_json_io_matches!(serde_create(&vec3), { "x": 1, "y": 2, "z": 3 });
-    });
-}
-
-#[test]
 fn union_integers() {
     "
     def level (

--- a/ontol/ontol-lsp/src/lib.rs
+++ b/ontol/ontol-lsp/src/lib.rs
@@ -336,7 +336,8 @@ impl LanguageServer for Backend {
                 insp::Statement::DefStatement(stmt) => {
                     let modifiers = stmt
                         .modifiers()
-                        .map(|m| m.slice().to_string())
+                        .filter_map(|m| m.token())
+                        .map(|t| t.slice().to_string())
                         .collect::<Vec<_>>()
                         .join(" ");
                     let detail = (!modifiers.is_empty()).then_some(modifiers);
@@ -376,7 +377,8 @@ impl LanguageServer for Backend {
                 insp::Statement::MapStatement(stmt) => {
                     let modifiers = stmt
                         .modifiers()
-                        .map(|m| m.slice().to_string())
+                        .filter_map(|m| m.token())
+                        .map(|t| t.slice().to_string())
                         .collect::<Vec<_>>()
                         .join(" ");
                     let detail = (!modifiers.is_empty()).then_some(modifiers);

--- a/ontol/ontol-lsp/src/state.rs
+++ b/ontol/ontol-lsp/src/state.rs
@@ -493,7 +493,8 @@ impl State {
                                 insp::Pattern::PatStruct(pat) => {
                                     let mut modifiers = pat
                                         .modifiers()
-                                        .map(|m| m.slice().to_string())
+                                        .filter_map(|m| m.token())
+                                        .map(|t| t.slice().to_string())
                                         .collect::<Vec<_>>()
                                         .join(" ");
                                     if !modifiers.is_empty() {
@@ -516,8 +517,8 @@ impl State {
                                     format!("{}{}({})", modifiers, path, ellipsis)
                                 }
                                 insp::Pattern::PatSet(pat) => {
-                                    let modifiers = match pat.modifier() {
-                                        Some(m) => format!("{} ", m.slice()),
+                                    let modifiers = match pat.modifier().and_then(|m| m.token()) {
+                                        Some(t) => format!("{} ", t.slice()),
                                         None => "".to_string(),
                                     };
                                     let path = match pat.ident_path() {

--- a/ontol/ontol-lsp/src/state.rs
+++ b/ontol/ontol-lsp/src/state.rs
@@ -202,11 +202,9 @@ impl State {
                         }
                         insp::Statement::MapStatement(_) => {}
                         insp::Statement::RelStatement(stmt) => {
-                            if let Some(set) = stmt.relation_set() {
-                                for relation in set.relations() {
-                                    if let Some(params) = relation.rel_params() {
-                                        cst_explore(params.statements(), aliases, defs);
-                                    }
+                            if let Some(relation) = stmt.relation() {
+                                if let Some(params) = relation.rel_params() {
+                                    cst_explore(params.statements(), aliases, defs);
                                 }
                             }
                         }

--- a/ontol/ontol-parser/src/cst/grammar.rs
+++ b/ontol/ontol-parser/src/cst/grammar.rs
@@ -168,19 +168,9 @@ mod rel {
         rel_type_reference(p, TypeAccept::all());
         p.end(subject);
 
-        let relation_set = p.start(Kind::RelationSet);
-        loop {
-            let relation = p.start(Kind::Relation);
-            forward_relation(p);
-            p.end(relation);
-
-            if matches!(p.at(), K![|]) {
-                p.eat(K![|]);
-            } else {
-                break;
-            }
-        }
-        p.end(relation_set);
+        let relation = p.start(Kind::Relation);
+        forward_relation(p);
+        p.end(relation);
 
         p.eat(K![:]);
 

--- a/ontol/ontol-parser/src/cst/grammar.rs
+++ b/ontol/ontol-parser/src/cst/grammar.rs
@@ -65,7 +65,7 @@ fn statement(p: &mut CstParser) {
 
     let kind = match p.at() {
         K![domain] => {
-            def_like_statement(K![domain], p, |p| {
+            def_like_statement(K![domain], Kind::DefModifier, p, |p| {
                 let ident = p.start(Kind::Ulid);
                 p.eat_while(|kind| matches!(kind, Kind::Number | Kind::Symbol));
                 p.end(ident);
@@ -77,7 +77,7 @@ fn statement(p: &mut CstParser) {
             Kind::UseStatement
         }
         K![def] => {
-            def_like_statement(K![def], p, |p| {
+            def_like_statement(K![def], Kind::DefModifier, p, |p| {
                 let ident = p.start(Kind::IdentPath);
                 p.eat(Kind::Symbol);
                 p.end(ident);
@@ -130,10 +130,15 @@ fn use_statement(p: &mut CstParser) {
     p.end(path);
 }
 
-fn def_like_statement(keyword: Kind, p: &mut CstParser, parse_ident: fn(&mut CstParser)) {
+fn def_like_statement(
+    keyword: Kind,
+    modifier: Kind,
+    p: &mut CstParser,
+    parse_ident: fn(&mut CstParser),
+) {
     p.eat(keyword);
 
-    p.eat_modifiers();
+    p.eat_modifiers(modifier);
     p.eat_trivia();
 
     parse_ident(p);
@@ -451,7 +456,7 @@ mod map {
     pub fn statement(p: &mut CstParser) {
         p.eat(K![map]);
 
-        p.eat_modifiers();
+        p.eat_modifiers(Kind::MapModifier);
 
         if p.at() == Kind::Symbol {
             let ident = p.start(Kind::IdentPath);
@@ -558,7 +563,7 @@ mod struct_pattern {
     pub fn entry(p: &mut CstParser) {
         let pat = p.start(Kind::PatStruct);
 
-        p.eat_modifiers();
+        p.eat_modifiers(Kind::PatStructModifier);
 
         if p.at() == Kind::Symbol {
             ident_path(p);
@@ -636,7 +641,7 @@ mod set_pattern {
     pub fn entry(p: &mut CstParser) {
         let pat = p.start(Kind::PatSet);
 
-        p.eat_modifiers();
+        p.eat_modifiers(Kind::PatSetModifier);
 
         if p.at() == Kind::Symbol {
             ident_path(p);

--- a/ontol/ontol-parser/src/cst/inspect.rs
+++ b/ontol/ontol-parser/src/cst/inspect.rs
@@ -204,6 +204,9 @@ node_union!(StructParam {
     StructParamAttrUnit,
 });
 
+#[derive(Clone, Copy)]
+pub struct Modifier<V>(pub V);
+
 #[derive(Clone)]
 pub enum TypeQuantOrPattern<V> {
     TypeQuant(TypeQuant<V>),
@@ -237,8 +240,8 @@ impl<V: NodeView> UseStatement<V> {
 }
 
 impl<V: NodeView> DefStatement<V> {
-    pub fn modifiers(&self) -> impl Iterator<Item = V::Token> {
-        self.view().local_tokens_filter(Kind::Modifier)
+    pub fn modifiers(&self) -> impl Iterator<Item = Modifier<V>> {
+        self.view().sub_nodes().filter_map(Modifier::from_view)
     }
 
     pub fn ident_path(&self) -> Option<IdentPath<V>> {
@@ -379,8 +382,8 @@ impl<V: NodeView> FmtStatement<V> {
 }
 
 impl<V: NodeView> MapStatement<V> {
-    pub fn modifiers(&self) -> impl Iterator<Item = V::Token> {
-        self.view().local_tokens_filter(Kind::Modifier)
+    pub fn modifiers(&self) -> impl Iterator<Item = Modifier<V>> {
+        self.view().sub_nodes().filter_map(Modifier::from_view)
     }
 
     pub fn ident_path(&self) -> Option<IdentPath<V>> {
@@ -433,8 +436,8 @@ impl<V: NodeView> TypeUnion<V> {
 }
 
 impl<V: NodeView> PatStruct<V> {
-    pub fn modifiers(&self) -> impl Iterator<Item = V::Token> {
-        self.view().local_tokens_filter(Kind::Modifier)
+    pub fn modifiers(&self) -> impl Iterator<Item = Modifier<V>> {
+        self.view().sub_nodes().filter_map(Modifier::from_view)
     }
 
     pub fn ident_path(&self) -> Option<IdentPath<V>> {
@@ -477,8 +480,8 @@ impl<V: NodeView> StructParamAttrUnit<V> {
 }
 
 impl<V: NodeView> PatSet<V> {
-    pub fn modifier(&self) -> Option<V::Token> {
-        self.view().local_tokens_filter(Kind::Modifier).next()
+    pub fn modifier(&self) -> Option<Modifier<V>> {
+        self.view().sub_nodes().find_map(Modifier::from_view)
     }
 
     pub fn ident_path(&self) -> Option<IdentPath<V>> {
@@ -577,6 +580,32 @@ impl<V: NodeView> NumberRange<V> {
 impl<V: NodeView> Spread<V> {
     pub fn symbol(&self) -> Option<V::Token> {
         self.view().local_tokens_filter(Kind::Symbol).next()
+    }
+}
+
+impl<V: NodeView> Modifier<V> {
+    pub fn token(&self) -> Option<V::Token> {
+        self.view().local_tokens_filter(Kind::Modifier).next()
+    }
+}
+
+impl<V: NodeView> TypedView<V> for Modifier<V> {
+    fn view(&self) -> &V {
+        &self.0
+    }
+
+    fn into_view(self) -> V {
+        self.0
+    }
+
+    fn from_view(view: V) -> Option<Self> {
+        match view.kind() {
+            Kind::DefModifier
+            | Kind::MapModifier
+            | Kind::PatSetModifier
+            | Kind::PatStructModifier => Some(Self(view)),
+            _ => None,
+        }
     }
 }
 

--- a/ontol/ontol-parser/src/cst/inspect.rs
+++ b/ontol/ontol-parser/src/cst/inspect.rs
@@ -124,7 +124,6 @@ nodes!(Node {
     ArcVar,
     ArcTypeParam,
     RelStatement,
-    RelationSet,
     Relation,
     RelSubject,
     RelObject,
@@ -316,8 +315,8 @@ impl<V: NodeView> RelStatement<V> {
         self.view().sub_nodes().find_map(RelSubject::from_view)
     }
 
-    pub fn relation_set(&self) -> Option<RelationSet<V>> {
-        self.view().sub_nodes().find_map(RelationSet::from_view)
+    pub fn relation(&self) -> Option<Relation<V>> {
+        self.view().sub_nodes().find_map(Relation::from_view)
     }
 
     pub fn object(&self) -> Option<RelObject<V>> {
@@ -340,12 +339,6 @@ impl<V: NodeView> RelObject<V> {
                 Pattern::from_view(view).map(TypeQuantOrPattern::Pattern)
             }
         })
-    }
-}
-
-impl<V: NodeView> RelationSet<V> {
-    pub fn relations(&self) -> impl Iterator<Item = Relation<V>> {
-        self.view().sub_nodes().filter_map(Relation::from_view)
     }
 }
 

--- a/ontol/ontol-parser/src/cst/parser.rs
+++ b/ontol/ontol-parser/src/cst/parser.rs
@@ -185,9 +185,12 @@ impl<'a> CstParser<'a> {
         }
     }
 
-    pub fn eat_modifiers(&mut self) {
+    pub fn eat_modifiers(&mut self, kind: Kind) {
         while self.at() == Kind::Modifier {
+            self.eat_space();
+            let node = self.start(kind);
             self.eat(Kind::Modifier);
+            self.end(node);
         }
     }
 

--- a/ontol/ontol-parser/src/lexer/kind.rs
+++ b/ontol/ontol-parser/src/lexer/kind.rs
@@ -164,7 +164,6 @@ pub enum Kind {
 
     /// rel statement
     RelStatement,
-    RelationSet,
     Relation,
     RelSubject,
     RelObject,
@@ -367,7 +366,6 @@ impl Display for Kind {
             Kind::ArcVar => write!(f, "arc variable"),
             Kind::ArcTypeParam => write!(f, "edge type parameter"),
             Kind::RelStatement => write!(f, "rel statement"),
-            Kind::RelationSet => write!(f, "relation set"),
             Kind::Relation => write!(f, "relation"),
             Kind::RelSubject => write!(f, "subject"),
             Kind::RelObject => write!(f, "object"),

--- a/ontol/ontol-parser/src/lexer/kind.rs
+++ b/ontol/ontol-parser/src/lexer/kind.rs
@@ -143,6 +143,7 @@ pub enum Kind {
 
     /// def statement
     DefStatement,
+    DefModifier,
     DefBody,
 
     /// sym statement
@@ -175,6 +176,7 @@ pub enum Kind {
 
     /// map statement
     MapStatement,
+    MapModifier,
     MapArm,
 
     // types
@@ -210,8 +212,10 @@ pub enum Kind {
     // patterns
     /// `struct(..)`
     PatStruct,
+    PatStructModifier,
     /// `set { }`
     PatSet,
+    PatSetModifier,
     /// `variable`, `42`, `'text'`, `/regex/`
     PatAtom,
     /// `a + b`
@@ -237,6 +241,12 @@ pub enum Kind {
 
     /// The root node. This should be the last entry in the enum.
     Ontol,
+}
+
+impl Kind {
+    pub fn is_trivia(&self) -> bool {
+        matches!(self, Self::Whitespace | Self::Comment)
+    }
 }
 
 pub trait KindFilter {
@@ -346,6 +356,7 @@ impl Display for Kind {
             Kind::DomainStatement => write!(f, "domain statement"),
             Kind::UseStatement => write!(f, "use statement"),
             Kind::DefStatement => write!(f, "def statement"),
+            Kind::DefModifier => write!(f, "def modifier"),
             Kind::DefBody => write!(f, "def body"),
             Kind::SymStatement => write!(f, "sym statement"),
             Kind::SymRelation => write!(f, "sym relation"),
@@ -364,6 +375,7 @@ impl Display for Kind {
             Kind::PropCardinality => write!(f, "property cardinality"),
             Kind::FmtStatement => write!(f, "fmt statement"),
             Kind::MapStatement => write!(f, "map statement"),
+            Kind::MapModifier => write!(f, "map modifier"),
             Kind::MapArm => write!(f, "map arm"),
             Kind::TypeQuantUnit => write!(f, "unit type quantifier"),
             Kind::TypeQuantSet => write!(f, "set type quantifier"),
@@ -380,7 +392,9 @@ impl Display for Kind {
             Kind::IdentPath => write!(f, "ident path"),
             Kind::Ulid => write!(f, "unique identifier"),
             Kind::PatStruct => write!(f, "struct pattern"),
+            Kind::PatStructModifier => write!(f, "struct modifier"),
             Kind::PatSet => write!(f, "set pattern"),
+            Kind::PatSetModifier => write!(f, "set modifier"),
             Kind::PatAtom => write!(f, "atom patterm"),
             Kind::PatBinary => write!(f, "binary pattern"),
             Kind::StructParamAttrProp => write!(f, "property attribute"),

--- a/ontol/ontol-parser/test-cases/cst/doc_comments.test
+++ b/ontol/ontol-parser/test-cases/cst/doc_comments.test
@@ -30,12 +30,11 @@ Ontol
                         ThisSet
                             Star `*`
                 Whitespace
-                RelationSet
-                    Relation
-                        TypeQuantUnit
-                            Literal
-                                SingleQuoteText `'a'`
-                        PropCardinality
+                Relation
+                    TypeQuantUnit
+                        Literal
+                            SingleQuoteText `'a'`
+                    PropCardinality
                 Colon `:`
                 Whitespace
                 RelObject
@@ -52,12 +51,11 @@ Ontol
                         ThisSet
                             Star `*`
                 Whitespace
-                RelationSet
-                    Relation
-                        TypeQuantUnit
-                            Literal
-                                SingleQuoteText `'b'`
-                        PropCardinality
+                Relation
+                    TypeQuantUnit
+                        Literal
+                            SingleQuoteText `'b'`
+                    PropCardinality
                 Colon `:`
                 Whitespace
                 RelObject

--- a/ontol/ontol-parser/test-cases/cst/domain_statement.test
+++ b/ontol/ontol-parser/test-cases/cst/domain_statement.test
@@ -21,12 +21,11 @@ Ontol
                         ThisUnit
                             Dot `.`
                 Whitespace
-                RelationSet
-                    Relation
-                        TypeQuantUnit
-                            IdentPath
-                                Symbol `version`
-                        PropCardinality
+                Relation
+                    TypeQuantUnit
+                        IdentPath
+                            Symbol `version`
+                    PropCardinality
                 Colon `:`
                 Whitespace
                 RelObject

--- a/ontol/ontol-parser/test-cases/cst/map_set.test
+++ b/ontol/ontol-parser/test-cases/cst/map_set.test
@@ -22,7 +22,8 @@ Ontol
                     Spread
                         DotDot `..`
                     PatStruct
-                        Modifier `@match`
+                        PatStructModifier
+                            Modifier `@match`
                         Whitespace
                         IdentPath
                             Symbol `foo`

--- a/ontol/ontol-parser/test-cases/cst/pattern_complex1.test
+++ b/ontol/ontol-parser/test-cases/cst/pattern_complex1.test
@@ -2,7 +2,8 @@
 
 //@ grammar=pattern
 PatStruct
-    Modifier `@match`
+    PatStructModifier
+        Modifier `@match`
     Whitespace
     IdentPath
         Symbol `bar`
@@ -14,7 +15,8 @@ PatStruct
         Colon `:`
         Whitespace
         PatSet
-            Modifier `@in`
+            PatSetModifier
+                Modifier `@in`
             Whitespace
             CurlyOpen `{`
             Whitespace

--- a/ontol/ontol-parser/test-cases/cst/rel_statement1.test
+++ b/ontol/ontol-parser/test-cases/cst/rel_statement1.test
@@ -1,5 +1,5 @@
 /// comment
-rel {.} 'id'[rel* gen: auto]?|id: text
+rel {.} 'id'[rel* gen: auto]?: text
 
 //@ grammar=ontol
 Ontol
@@ -15,41 +15,33 @@ Ontol
                     Dot `.`
                 CurlyClose `}`
         Whitespace
-        RelationSet
-            Relation
-                TypeQuantUnit
-                    Literal
-                        SingleQuoteText `'id'`
-                RelParams
-                    SquareOpen `[`
-                    RelStatement
-                        KwRel `rel`
-                        RelSubject
-                            TypeQuantUnit
-                                ThisSet
-                                    Star `*`
-                        Whitespace
-                        RelationSet
-                            Relation
-                                TypeQuantUnit
-                                    IdentPath
-                                        Symbol `gen`
-                                PropCardinality
-                        Colon `:`
-                        Whitespace
-                        RelObject
-                            TypeQuantUnit
-                                IdentPath
-                                    Symbol `auto`
-                    SquareClose `]`
-                PropCardinality
-                    Question `?`
-            Pipe `|`
-            Relation
-                TypeQuantUnit
-                    IdentPath
-                        Symbol `id`
-                PropCardinality
+        Relation
+            TypeQuantUnit
+                Literal
+                    SingleQuoteText `'id'`
+            RelParams
+                SquareOpen `[`
+                RelStatement
+                    KwRel `rel`
+                    RelSubject
+                        TypeQuantUnit
+                            ThisSet
+                                Star `*`
+                    Whitespace
+                    Relation
+                        TypeQuantUnit
+                            IdentPath
+                                Symbol `gen`
+                        PropCardinality
+                    Colon `:`
+                    Whitespace
+                    RelObject
+                        TypeQuantUnit
+                            IdentPath
+                                Symbol `auto`
+                SquareClose `]`
+            PropCardinality
+                Question `?`
         Colon `:`
         Whitespace
         RelObject

--- a/ontol/ontol-parser/test-cases/cst/rel_statement2.test
+++ b/ontol/ontol-parser/test-cases/cst/rel_statement2.test
@@ -12,12 +12,11 @@ Ontol
                 ThisSet
                     Star `*`
         Whitespace
-        RelationSet
-            Relation
-                TypeQuantUnit
-                    Literal
-                        SingleQuoteText `'a'`
-                PropCardinality
+        Relation
+            TypeQuantUnit
+                Literal
+                    SingleQuoteText `'a'`
+            PropCardinality
         Colon `:`
         RelObject
             TypeQuantUnit

--- a/ontol/ontol-parser/test-cases/cst/rel_statement3.test
+++ b/ontol/ontol-parser/test-cases/cst/rel_statement3.test
@@ -1,4 +1,4 @@
-rel. 'id'|id: (rel* is: text)
+rel. 'id': (rel* is: text)
 
 //@ grammar=ontol
 Ontol
@@ -9,18 +9,11 @@ Ontol
                 ThisUnit
                     Dot `.`
         Whitespace
-        RelationSet
-            Relation
-                TypeQuantUnit
-                    Literal
-                        SingleQuoteText `'id'`
-                PropCardinality
-            Pipe `|`
-            Relation
-                TypeQuantUnit
-                    IdentPath
-                        Symbol `id`
-                PropCardinality
+        Relation
+            TypeQuantUnit
+                Literal
+                    SingleQuoteText `'id'`
+            PropCardinality
         Colon `:`
         Whitespace
         RelObject
@@ -34,12 +27,11 @@ Ontol
                                 ThisSet
                                     Star `*`
                         Whitespace
-                        RelationSet
-                            Relation
-                                TypeQuantUnit
-                                    IdentPath
-                                        Symbol `is`
-                                PropCardinality
+                        Relation
+                            TypeQuantUnit
+                                IdentPath
+                                    Symbol `is`
+                            PropCardinality
                         Colon `:`
                         Whitespace
                         RelObject

--- a/ontol/ontol-parser/test-cases/cst/rel_statement4.test
+++ b/ontol/ontol-parser/test-cases/cst/rel_statement4.test
@@ -9,16 +9,15 @@ Ontol
                 ThisSet
                     Star `*`
         Whitespace
-        RelationSet
-            Relation
-                TypeQuantUnit
-                    NumberRange
-                        RangeStart
-                            Number `0`
-                        DotDot `..`
-                        RangeEnd
-                            Number `42`
-                PropCardinality
+        Relation
+            TypeQuantUnit
+                NumberRange
+                    RangeStart
+                        Number `0`
+                    DotDot `..`
+                    RangeEnd
+                        Number `42`
+            PropCardinality
         Colon `:`
         Whitespace
         RelObject

--- a/ontol/ontol-parser/test-cases/cst/rel_statement5.test
+++ b/ontol/ontol-parser/test-cases/cst/rel_statement5.test
@@ -1,4 +1,4 @@
-rel* a|b: c|d
+rel* a: b|c
 
 //@ grammar=ontol
 Ontol
@@ -9,26 +9,19 @@ Ontol
                 ThisSet
                     Star `*`
         Whitespace
-        RelationSet
-            Relation
-                TypeQuantUnit
-                    IdentPath
-                        Symbol `a`
-                PropCardinality
-            Pipe `|`
-            Relation
-                TypeQuantUnit
-                    IdentPath
-                        Symbol `b`
-                PropCardinality
+        Relation
+            TypeQuantUnit
+                IdentPath
+                    Symbol `a`
+            PropCardinality
         Colon `:`
         Whitespace
         RelObject
             TypeQuantUnit
                 TypeUnion
                     IdentPath
-                        Symbol `c`
+                        Symbol `b`
                     Pipe `|`
                     IdentPath
-                        Symbol `d`
+                        Symbol `c`
     Whitespace

--- a/ontol/ontol-parser/test-cases/cst/rel_statement6.test
+++ b/ontol/ontol-parser/test-cases/cst/rel_statement6.test
@@ -1,4 +1,4 @@
-rel a|b c|d: {e|f}
+rel a|b c: {d|e}
 
 //@ grammar=ontol
 Ontol
@@ -14,18 +14,11 @@ Ontol
                     IdentPath
                         Symbol `b`
         Whitespace
-        RelationSet
-            Relation
-                TypeQuantUnit
-                    IdentPath
-                        Symbol `c`
-                PropCardinality
-            Pipe `|`
-            Relation
-                TypeQuantUnit
-                    IdentPath
-                        Symbol `d`
-                PropCardinality
+        Relation
+            TypeQuantUnit
+                IdentPath
+                    Symbol `c`
+            PropCardinality
         Colon `:`
         Whitespace
         RelObject
@@ -33,9 +26,9 @@ Ontol
                 CurlyOpen `{`
                 TypeUnion
                     IdentPath
-                        Symbol `e`
+                        Symbol `d`
                     Pipe `|`
                     IdentPath
-                        Symbol `f`
+                        Symbol `e`
                 CurlyClose `}`
     Whitespace


### PR DESCRIPTION
One change is user-visible and the other is more technical/internal.

The user-visible change is the removal of RelationSet: `rel subject a|b: object`. That is, `a|b` syntax is no longer supported, there are no important use cases for it anymore. This makes it much easier to develop ontol-log, because now each logical relation is tied 1:1 with a `rel` statement.

The other more invisible change is a proper syntax tree node around modifiers, instead of just using tagged tokens. This also simplifies the code in ontol-log.