### PR TITLE
feat: subdomain support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,7 +1852,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "ulid",
  "unimock",
 ]
 

--- a/domain-engine/domain-engine-core/src/search.rs
+++ b/domain-engine/domain-engine-core/src/search.rs
@@ -1,6 +1,5 @@
-use ontol_runtime::value::Value;
+use ontol_runtime::{DomainId, value::Value};
 use serde::{Deserialize, Serialize};
-use ulid::Ulid;
 
 #[derive(Serialize, Deserialize)]
 pub struct VertexSearchParams {
@@ -26,7 +25,7 @@ impl SearchFilters {
 
 #[derive(Default, Serialize, Deserialize)]
 pub struct SearchDomainOrDef {
-    pub domain_id: Ulid,
+    pub domain_id: DomainId,
     pub def_tag: Option<u16>,
 }
 

--- a/domain-engine/domain-engine-graphql/Cargo.toml
+++ b/domain-engine/domain-engine-graphql/Cargo.toml
@@ -25,7 +25,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio = { version = "1", features = ["sync"] }
 tracing.workspace = true
-ulid = "1"
 
 
 [dev-dependencies]

--- a/domain-engine/domain-engine-graphql/src/ontology/gql_def.rs
+++ b/domain-engine/domain-engine-graphql/src/ontology/gql_def.rs
@@ -62,7 +62,7 @@ impl Def {
     fn id(&self, ctx: &OntologyCtx) -> gql_id::DefId {
         let domain = ctx.domain_by_index(self.id.domain_index()).unwrap();
         gql_id::DefId {
-            domain_id: domain.domain_id().ulid,
+            domain_id: domain.domain_id().id,
             def_tag: self.id.1,
         }
     }

--- a/domain-engine/domain-engine-graphql/src/ontology/gql_domain.rs
+++ b/domain-engine/domain-engine-graphql/src/ontology/gql_domain.rs
@@ -15,7 +15,7 @@ pub struct Domain {
 #[graphql(context = OntologyCtx, scalar = GqlScalar)]
 impl Domain {
     fn id(&self, ctx: &OntologyCtx) -> juniper::ID {
-        self.data(ctx).domain_id().ulid.to_string().into()
+        self.data(ctx).domain_id().id.to_string().into()
     }
 
     fn id_stable(&self, ctx: &OntologyCtx) -> bool {

--- a/domain-engine/domain-engine-graphql/src/ontology/gql_id.rs
+++ b/domain-engine/domain-engine-graphql/src/ontology/gql_id.rs
@@ -1,8 +1,8 @@
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
 
 use ::juniper::FieldResult;
 use compact_str::CompactString;
-use ulid::Ulid;
+use ontol_runtime::DomainId;
 
 use crate::{gql_scalar::GqlScalar, juniper};
 
@@ -16,7 +16,7 @@ use super::OntologyCtx;
     parse_token_with = DefId::parse_token,
 )]
 pub struct DefId {
-    pub domain_id: Ulid,
+    pub domain_id: DomainId,
     pub def_tag: u16,
 }
 
@@ -50,13 +50,10 @@ impl DefId {
         };
 
         let (domain_id, tag) = string.split_once(":").ok_or(DefIdParseError::BadFormat)?;
-        let ulid = Ulid::from_string(domain_id).map_err(|_| DefIdParseError::BadFormat)?;
+        let domain_id = DomainId::from_str(domain_id).map_err(|_| DefIdParseError::BadFormat)?;
         let def_tag: u16 = tag.parse().map_err(|_| DefIdParseError::BadFormat)?;
 
-        Ok(DefId {
-            domain_id: ulid,
-            def_tag,
-        })
+        Ok(DefId { domain_id, def_tag })
     }
 
     fn parse_token(token: juniper::ScalarToken<'_>) -> juniper::ParseScalarResult<GqlScalar> {

--- a/domain-engine/domain-engine-graphql/src/ontology/gql_query.rs
+++ b/domain-engine/domain-engine-graphql/src/ontology/gql_query.rs
@@ -23,10 +23,9 @@ use ontol_runtime::query::select::StructOrUnionSelect;
 use ontol_runtime::query::select::StructSelect;
 use ontol_runtime::query::select::{EntitySelect, Select};
 use ontol_runtime::value::{OctetSequence, Value};
-use ontol_runtime::{OntolDefTag, OntolDefTagExt, PropId};
+use ontol_runtime::{DomainId, OntolDefTag, OntolDefTagExt, PropId};
 use serde::Deserialize;
 use serde::de::value::StringDeserializer;
-use ulid::Ulid;
 
 use super::OntologyCtx;
 use super::gql_dictionary;
@@ -52,8 +51,8 @@ impl Query {
         ctx: &OntologyCtx,
     ) -> FieldResult<gql_domain::Domain> {
         let domain = if let Some(id) = id {
-            let id = Ulid::from_string(&id)?;
-            ctx.domains().find(|(_, d)| d.domain_id().ulid == id)
+            let domain_id = DomainId::from_str(&id)?;
+            ctx.domains().find(|(_, d)| d.domain_id().id == domain_id)
         } else if let Some(name) = name {
             ctx.domains()
                 .find(|(_, d)| ctx.get_text_constant(d.unique_name()).to_string() == name)

--- a/domain-engine/domain-engine-graphql/src/ontology/gql_value.rs
+++ b/domain-engine/domain-engine-graphql/src/ontology/gql_value.rs
@@ -97,7 +97,7 @@ pub fn write_ontol_scalar(
     if cfg.with_def_id {
         if let Some(domain) = ctx.domain_by_index(def_id.0) {
             let gql_def_id = gql_id::DefId {
-                domain_id: domain.domain_id().ulid,
+                domain_id: domain.domain_id().id,
                 def_tag: def_id.1,
             };
 

--- a/domain-engine/domain-engine-graphql/tests/graphql-integration/test_graphql_ontology.rs
+++ b/domain-engine/domain-engine-graphql/tests/graphql-integration/test_graphql_ontology.rs
@@ -40,7 +40,7 @@ fn expected_defs() -> juniper::Value<GqlScalar> {
             let mut obj = juniper::Object::with_capacity(2);
             obj.add_field(
                 "id",
-                format!("01GNYFZP30ED0EZ1579TH0D55P:{}", self.next_tag).into(),
+                format!("01GNYFZP30ED0EZ1579TH0D55P§0:{}", self.next_tag).into(),
             );
             obj.add_field("ident", ident.into());
             obj.add_field("kind", kind.into());
@@ -129,11 +129,11 @@ async fn test_ontology_ontol(ds: &str) {
         expected = Ok(graphql_value!({
             "domains": [
                 {
-                    "id": "01GNYFZP30ED0EZ1579TH0D55P",
+                    "id": "01GNYFZP30ED0EZ1579TH0D55P§0",
                     "name": "ontol",
                 },
                 {
-                    "id": "7ZZZZZZZZZZTESTZZZZZZZZZZZ",
+                    "id": "7ZZZZZZZZZZTESTZZZZZZZZZZZ§0",
                     "name": "test"
                 }
             ]
@@ -143,7 +143,7 @@ async fn test_ontology_ontol(ds: &str) {
     expect_eq!(
         actual = r#"
             {
-                domain(id: "01GNYFZP30ED0EZ1579TH0D55P") {
+                domain(id: "01GNYFZP30ED0EZ1579TH0D55P§0") {
                     defs {
                         id
                         ident
@@ -238,31 +238,31 @@ async fn test_ontology_stix(ds: &str) {
         expected = Ok(graphql_value!({
             "domains": [
                 {
-                    "id": "01GNYFZP30ED0EZ1579TH0D55P",
+                    "id": "01GNYFZP30ED0EZ1579TH0D55P§0",
                     "name": "ontol",
                 },
                 {
-                    "id": "01GZ13EAM0RY693MSJ75XZARHY",
+                    "id": "01GZ13EAM0RY693MSJ75XZARHY§0",
                     "name": "stix",
                 },
                 {
-                    "id": "01J5C5GB45Q3C0E4YYRPP8SN4R",
+                    "id": "01J5C5GB45Q3C0E4YYRPP8SN4R§0",
                     "name": "stix_common",
                 },
                 {
-                    "id": "01J6SACJ2A3P8FNEQ2S20M3DV7",
+                    "id": "01J6SACJ2A3P8FNEQ2S20M3DV7§0",
                     "name": "stix_edges",
                 },
                 {
-                    "id": "01H7ZN6PJ0NHEFMHW2PBN4FEPZ",
+                    "id": "01H7ZN6PJ0NHEFMHW2PBN4FEPZ§0",
                     "name": "stix_interface",
                 },
                 {
-                    "id": "01J5C5JJKM7XWR56TTYH9B7VRN",
+                    "id": "01J5C5JJKM7XWR56TTYH9B7VRN§0",
                     "name": "stix_open_vocab",
                 },
                 {
-                    "id": "01H7ZZ5KMG538CXJMNJQVTMP9K",
+                    "id": "01H7ZZ5KMG538CXJMNJQVTMP9K§0",
                     "name": "SI",
                 },
             ]
@@ -292,7 +292,7 @@ async fn test_ontology_stix(ds: &str) {
         .await,
         expected = Ok(graphql_value!({
             "def": {
-                "id": "01GZ13EAM0RY693MSJ75XZARHY:54",
+                "id": "01GZ13EAM0RY693MSJ75XZARHY§0:54",
                 "kind": "ENTITY",
                 "dataRelationships": [
                     { "propId": "p@1:54:0", "name": "type" },
@@ -477,7 +477,7 @@ async fn test_ontology_stix(ds: &str) {
         let update_time_prop_id = {
             let ontol_update_time = r#"
             {
-                domain(id: "01GNYFZP30ED0EZ1579TH0D55P") {
+                domain(id: "01GNYFZP30ED0EZ1579TH0D55P§0") {
                     defs(ident: "update_time") {
                         propId
                     }

--- a/domain-engine/domain-engine-graphql/tests/graphql-integration/test_graphql_search.rs
+++ b/domain-engine/domain-engine-graphql/tests/graphql-integration/test_graphql_search.rs
@@ -116,7 +116,7 @@ async fn test_conduit_search(ds: &str) {
                 "results": [
                     {
                         "vertex": {
-                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES:5",
+                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES§0:5",
                             "type": "struct",
                             "update_time": "1976-01-01T00:00:00Z"
                         },
@@ -124,7 +124,7 @@ async fn test_conduit_search(ds: &str) {
                     },
                     {
                         "vertex": {
-                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES:5",
+                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES§0:5",
                             "type": "struct",
                             "update_time": "1975-01-01T00:00:00Z"
                         },
@@ -132,7 +132,7 @@ async fn test_conduit_search(ds: &str) {
                     },
                     {
                         "vertex": {
-                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES:4",
+                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES§0:4",
                             "type": "struct",
                             "update_time": "1972-01-01T00:00:00Z"
                         },
@@ -140,7 +140,7 @@ async fn test_conduit_search(ds: &str) {
                     },
                     {
                         "vertex": {
-                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES:4",
+                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES§0:4",
                             "type": "struct",
                             "update_time": "1971-01-01T00:00:00Z"
                         },
@@ -156,7 +156,7 @@ async fn test_conduit_search(ds: &str) {
         actual = r#"{
             vertexSearch(
                 limit: 10
-                defFilters: ["01GZQ1ZRW0WJR72GHM6VWRMFES:5"]
+                defFilters: ["01GZQ1ZRW0WJR72GHM6VWRMFES§0:5"]
                 withAddress: false
                 withDefId: true
                 withAttrs: false
@@ -174,7 +174,7 @@ async fn test_conduit_search(ds: &str) {
                 "results": [
                     {
                         "vertex": {
-                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES:5",
+                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES§0:5",
                             "type": "struct",
                             "update_time": "1976-01-01T00:00:00Z"
                         },
@@ -182,7 +182,7 @@ async fn test_conduit_search(ds: &str) {
                     },
                     {
                         "vertex": {
-                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES:5",
+                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES§0:5",
                             "type": "struct",
                             "update_time": "1975-01-01T00:00:00Z"
                         },
@@ -220,7 +220,7 @@ async fn test_conduit_search(ds: &str) {
                 "results": [
                     {
                         "vertex": {
-                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES:5",
+                            "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES§0:5",
                             "type": "struct",
                             "update_time": "1976-01-01T00:00:00Z"
                         },
@@ -229,10 +229,10 @@ async fn test_conduit_search(ds: &str) {
                 ],
                 "facets": {
                     "domains": [
-                        { "domainId": "01GZQ1ZRW0WJR72GHM6VWRMFES", "count": 1 }
+                        { "domainId": "01GZQ1ZRW0WJR72GHM6VWRMFES§0", "count": 1 }
                     ],
                     "defs": [
-                        { "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES:5", "count": 1 }
+                        { "defId": "01GZQ1ZRW0WJR72GHM6VWRMFES§0:5", "count": 1 }
                     ]
                 },
             }
@@ -245,7 +245,7 @@ async fn test_conduit_search(ds: &str) {
             vertexSearch(
                 query: "DISASTERS"
                 limit: 10
-                defFilters: ["01GZQ1ZRW0WJR72GHM6VWRMFES:4"]
+                defFilters: ["01GZQ1ZRW0WJR72GHM6VWRMFES§0:4"]
                 withAddress: false
                 withDefId: true
                 withAttrs: false

--- a/domain-engine/domain-engine-httpjson/tests/integration/test_httpjson_workspace.rs
+++ b/domain-engine/domain-engine-httpjson/tests/integration/test_httpjson_workspace.rs
@@ -20,7 +20,7 @@ use ulid::Ulid;
 use crate::{MakeTestRouter, TestHttpError, make_domain_engine};
 
 /// id of the workspaces domain under test
-const DOMAIN_ID: &str = "01JAP41VG1STK1VZPWXV26SPNM";
+const DOMAIN_ID: &str = "01JAP41VG1STK1VZPWXV26SPNM§0";
 
 #[datastore_test(tokio::test)]
 async fn test_workspaces_rest_api_with_edit(ds: &str) {

--- a/domain-engine/domain-engine-store-pg/m6mreg_migrations/V3__subdomain.sql
+++ b/domain-engine/domain-engine-store-pg/m6mreg_migrations/V3__subdomain.sql
@@ -1,0 +1,3 @@
+ALTER TABLE m6mreg.domain ADD COLUMN subdomain integer NOT NULL DEFAULT 0;
+ALTER TABLE m6mreg.domain DROP CONSTRAINT domain_uid_key;
+CREATE UNIQUE INDEX domain_uid_subdomain_key ON m6mreg.domain USING btree (uid, subdomain);

--- a/domain-engine/domain-engine-store-pg/src/migrate/domain_schemas.rs
+++ b/domain-engine/domain-engine-store-pg/src/migrate/domain_schemas.rs
@@ -40,6 +40,9 @@ async fn migrate(_ctx: &mut MigrationCtx, version: RegVersion) -> anyhow::Result
         RegVersion::Crdt => {
             // nothing to do in domain schemas, the "crdt" table is created on demand.
         }
+        RegVersion::Subdomain => {
+            // nothing to do in domain schemas
+        }
     }
 
     Ok(())

--- a/domain-engine/domain-engine-store-pg/src/migrate/mod.rs
+++ b/domain-engine/domain-engine-store-pg/src/migrate/mod.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, anyhow};
 use deadpool_postgres::Object;
 use fnv::FnvHashMap;
 use ontol_runtime::{
-    DefId, DefPropTag, DomainIndex, OntolDefTag,
+    DefId, DefPropTag, DomainId, DomainIndex, OntolDefTag,
     ontology::{aspects::DefsAspect, domain::DefKind},
     tuple::CardinalIdx,
 };
@@ -16,8 +16,8 @@ use txn_wrapper::TxnWrapper;
 use crate::{
     PgModel,
     pg_model::{
-        DomainUid, PgDomain, PgEdgeCardinalKind, PgIndexType, PgPropertyData, PgTableIdUnion,
-        PgType, RegVersion,
+        PgDomain, PgEdgeCardinalKind, PgIndexType, PgPropertyData, PgTableIdUnion, PgType,
+        RegVersion,
     },
 };
 
@@ -38,7 +38,7 @@ const MIGRATIONS_TABLE_NAME: &str = "public.m6mreg_schema_history";
 #[derive(Clone, Copy)]
 struct PgDomainIds {
     index: DomainIndex,
-    uid: DomainUid,
+    id: DomainId,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
@@ -211,7 +211,7 @@ pub async fn migrate_ontology(
             .ok_or_else(|| anyhow!("domain does not exist"))?;
 
         steps::migrate_domain_steps(*domain_index, domain, ontology_defs, &mut ctx)
-            .instrument(debug_span!("migrate", uid = %domain.domain_id().ulid))
+            .instrument(debug_span!("migrate", uid = %domain.domain_id().id))
             .await
             .context("domain migration steps")?;
 

--- a/domain-engine/domain-engine-store-pg/src/migrate/steps.rs
+++ b/domain-engine/domain-engine-store-pg/src/migrate/steps.rs
@@ -31,10 +31,10 @@ pub async fn migrate_domain_steps(
     ontology_defs: &DefsAspect,
     ctx: &mut MigrationCtx,
 ) -> anyhow::Result<()> {
-    let domain_uid = domain.domain_id().ulid;
+    let domain_id = domain.domain_id().id;
     let domain_ids = PgDomainIds {
         index: domain_index,
-        uid: domain_uid,
+        id: domain_id,
     };
     let unique_name = &ontology_defs[domain.unique_name()];
     let pg_domain = ctx.domains.get_mut(&domain_index);

--- a/domain-engine/domain-engine-store-pg/src/pg_model.rs
+++ b/domain-engine/domain-engine-store-pg/src/pg_model.rs
@@ -28,8 +28,6 @@ pub type PgRegKey = i32;
 /// The key type used for data in the domains
 pub type PgDataKey = i64;
 
-pub type DomainUid = ulid::Ulid;
-
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct EdgeId(pub DefId);
 
@@ -213,11 +211,12 @@ impl From<Value> for InDomain<Value> {
 pub enum RegVersion {
     Init = 1,
     Crdt = 2,
+    Subdomain = 3,
 }
 
 impl RegVersion {
     pub const fn current() -> Self {
-        Self::Crdt
+        Self::Subdomain
     }
 }
 
@@ -228,6 +227,7 @@ impl TryFrom<u32> for RegVersion {
         match value {
             1 => Ok(Self::Init),
             2 => Ok(Self::Crdt),
+            3 => Ok(Self::Subdomain),
             other => Err(other),
         }
     }

--- a/domain-engine/domain-engine-tantivy/src/document.rs
+++ b/domain-engine/domain-engine-tantivy/src/document.rs
@@ -106,14 +106,13 @@ impl IndexingContext {
         doc.add_field_value(
             self.schema.facet,
             OwnedValue::Facet(
-                Facet::from_text(&format!("/def/{}:{}", domain.domain_id().ulid, def_id.1))
-                    .unwrap(),
+                Facet::from_text(&format!("/def/{}:{}", domain.domain_id().id, def_id.1)).unwrap(),
             ),
         );
         doc.add_field_value(
             self.schema.facet,
             OwnedValue::Facet(
-                Facet::from_text(&format!("/domain/{}", domain.domain_id().ulid)).unwrap(),
+                Facet::from_text(&format!("/domain/{}", domain.domain_id().id)).unwrap(),
             ),
         );
 

--- a/domain-engine/domain-engine-tantivy/src/search.rs
+++ b/domain-engine/domain-engine-tantivy/src/search.rs
@@ -8,7 +8,7 @@ use domain_engine_core::{
         VertexSearchResults,
     },
 };
-use ontol_runtime::DefId;
+use ontol_runtime::{DefId, DomainId};
 use tantivy::{
     DateTime, DocAddress, Order, Searcher, TantivyError, Term,
     collector::{FacetCollector, FacetCounts, TopDocs},
@@ -18,7 +18,6 @@ use tantivy::{
 };
 use tokio::task::JoinError;
 use tracing::{debug, error, info};
-use ulid::Ulid;
 
 use crate::{TantivyDataStoreLayer, schema::fieldname};
 
@@ -37,8 +36,8 @@ pub struct RawVertexHit {
 }
 
 enum ParsedFacet {
-    Domain(Ulid),
-    Def(Ulid, u16),
+    Domain(DomainId),
+    Def(DomainId, u16),
 }
 
 #[derive(displaydoc::Display, Debug)]

--- a/ontol/ontol-compiler/src/compile_domain.rs
+++ b/ontol/ontol-compiler/src/compile_domain.rs
@@ -97,7 +97,7 @@ impl Compiler<'_> {
             if self
                 .domain_ids
                 .values()
-                .any(|existing_domain_id| existing_domain_id.ulid == header_data.domain_id.0.ulid)
+                .any(|existing_domain_id| existing_domain_id.id == header_data.domain_id.0.id)
             {
                 CompileError::TODO("domain has already been compiled")
                     .span(SourceSpan {

--- a/ontol/ontol-compiler/src/lib.rs
+++ b/ontol/ontol-compiler/src/lib.rs
@@ -7,7 +7,7 @@ pub use error::*;
 use fnv::{FnvHashMap, FnvHashSet};
 use lowering::context::LoweringOutcome;
 use misc::MiscCtx;
-use ontol_core::{DomainId, TopologyGeneration, tag::DomainIndex, url::DomainUrl};
+use ontol_core::{OntologyDomainId, TopologyGeneration, tag::DomainIndex, url::DomainUrl};
 use ontol_parser::source::SourceId;
 use ontol_syntax::OntolSyntax;
 use primitive::init_ontol_primitives;
@@ -169,7 +169,7 @@ struct Compiler<'m> {
     namespaces: Namespaces<'m>,
     defs: Defs<'m>,
     domain_def_ids: FnvHashMap<DomainIndex, DefId>,
-    domain_ids: BTreeMap<DomainIndex, DomainId>,
+    domain_ids: BTreeMap<DomainIndex, OntologyDomainId>,
     domain_config_table: FnvHashMap<DomainIndex, DomainConfig>,
     topology_generation: FnvHashMap<DomainIndex, TopologyGeneration>,
     patterns: Patterns,

--- a/ontol/ontol-compiler/src/ontol_domain.rs
+++ b/ontol/ontol-compiler/src/ontol_domain.rs
@@ -3,7 +3,7 @@
 use std::{ops::Range, str::FromStr};
 
 use indexmap::IndexMap;
-use ontol_core::{DomainId, tag::DomainIndex};
+use ontol_core::{DomainId, OntologyDomainId, tag::DomainIndex};
 use ontol_hir::OverloadFunc;
 use ontol_macros::RustDoc;
 use ontol_parser::source::NO_SPAN;
@@ -69,8 +69,11 @@ impl<'m> Compiler<'m> {
         assert_eq!(ontol_def_id.domain_index(), DomainIndex::ontol());
         self.domain_ids.insert(
             ontol_def_id.domain_index(),
-            DomainId {
-                ulid: Ulid::from_str(ONTOL_DOMAIN_ID).unwrap(),
+            OntologyDomainId {
+                id: DomainId {
+                    ulid: Ulid::from_str(ONTOL_DOMAIN_ID).unwrap(),
+                    subdomain: 0,
+                },
                 stable: true,
             },
         );

--- a/ontol/ontol-core/src/lib.rs
+++ b/ontol/ontol-core/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{fmt::Display, str::FromStr, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
@@ -14,9 +14,23 @@ pub mod vec_map;
 
 extern crate self as ontol_core;
 
-#[derive(Clone, Serialize, Deserialize)]
+/// Global domain ID
+#[derive(
+    Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize,
+)]
 pub struct DomainId {
+    /// Unique identifier for the top level domain
     pub ulid: Ulid,
+    /// Subdomain tag
+    pub subdomain: u32,
+}
+
+/// Domain ID as used in an ontology
+#[derive(Clone, Serialize, Deserialize)]
+pub struct OntologyDomainId {
+    /// The ID
+    pub id: DomainId,
+    /// Whether the ULID is stable
     pub stable: bool,
 }
 
@@ -26,6 +40,24 @@ pub struct TopologyGeneration(pub u32);
 
 /// Thin wrapper around Arc<String> that implements AsRef<str>
 pub struct ArcString(pub Arc<String>);
+
+impl Display for DomainId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}§{}", self.ulid, self.subdomain)
+    }
+}
+
+impl FromStr for DomainId {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (ulid, subdomain) = s.split_once('§').unwrap_or((s, "0"));
+        Ok(Self {
+            ulid: Ulid::from_string(ulid).map_err(|_| "badly formatted domain ulid")?,
+            subdomain: u32::from_str(subdomain).map_err(|_| "badly formatted subdomain tag")?,
+        })
+    }
+}
 
 impl AsRef<str> for ArcString {
     fn as_ref(&self) -> &str {

--- a/ontol/ontol-parser/src/basic_syntax.rs
+++ b/ontol/ontol-parser/src/basic_syntax.rs
@@ -1,6 +1,8 @@
 use std::{panic::UnwindSafe, str::FromStr};
 
-use ontol_core::{DomainId, error::SpannedMsgError, span::U32Span, url::DomainUrlParser};
+use ontol_core::{
+    DomainId, OntologyDomainId, error::SpannedMsgError, span::U32Span, url::DomainUrlParser,
+};
 use ulid::Ulid;
 
 use crate::{
@@ -35,8 +37,11 @@ fn extract_ontol_header_data<V: NodeView>(
     let mut data = OntolHeaderData {
         domain_docs: None,
         domain_id: (
-            DomainId {
-                ulid: Default::default(),
+            OntologyDomainId {
+                id: DomainId {
+                    ulid: Default::default(),
+                    subdomain: 0,
+                },
                 stable: false,
             },
             U32Span::default(),
@@ -206,7 +211,13 @@ pub fn extract_domain_headerdata<V: NodeView>(
     if let Some((ulid, ulid_span)) = domain_ulid {
         OntolHeaderData {
             domain_docs,
-            domain_id: (DomainId { ulid, stable: true }, ulid_span),
+            domain_id: (
+                OntologyDomainId {
+                    id: DomainId { ulid, subdomain: 0 },
+                    stable: true,
+                },
+                ulid_span,
+            ),
             name: name.unwrap_or_else(|| (format!("{}", ulid), ulid_span)),
             deps: vec![],
         }
@@ -244,8 +255,8 @@ fn test_extract_header_data() {
 
     assert_eq!("docs1\ndocs2", header_data.domain_docs.unwrap());
     assert_eq!(
-        "7ZZZZZZZZZZTESTZZZZZZZZZZZ",
-        header_data.domain_id.0.ulid.to_string()
+        "7ZZZZZZZZZZTESTZZZZZZZZZZZ§0",
+        header_data.domain_id.0.id.to_string()
     );
     assert_eq!(1, header_data.deps.len());
 }

--- a/ontol/ontol-parser/src/topology.rs
+++ b/ontol/ontol-parser/src/topology.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use ontol_core::{
-    ArcString, DomainId, TopologyGeneration,
+    ArcString, DomainId, OntologyDomainId, TopologyGeneration,
     span::U32Span,
     tag::DomainIndex,
     url::{DomainUrl, DomainUrlResolver},
@@ -90,7 +90,7 @@ pub struct WithDocs(pub bool);
 /// Metadata extracted from the header section of a domain
 pub struct OntolHeaderData {
     pub domain_docs: Option<String>,
-    pub domain_id: (DomainId, U32Span),
+    pub domain_id: (OntologyDomainId, U32Span),
     pub name: (String, U32Span),
     pub deps: Vec<(DomainUrl, U32Span)>,
 }
@@ -110,8 +110,8 @@ impl OntolHeaderData {
         Self {
             domain_docs: None,
             domain_id: (
-                DomainId {
-                    ulid,
+                OntologyDomainId {
+                    id: DomainId { ulid, subdomain: 0 },
                     stable: false,
                 },
                 U32Span::default(),

--- a/ontol/ontol-runtime/src/lib.rs
+++ b/ontol/ontol-runtime/src/lib.rs
@@ -5,6 +5,7 @@ use std::{collections::BTreeSet, fmt::Debug, str::FromStr};
 use ::serde::{Deserialize, Serialize};
 use fnv::FnvBuildHasher;
 use indexmap::IndexMap;
+pub use ontol_core::DomainId;
 use ontol_core::impl_ontol_debug;
 pub use ontol_core::tag::{DomainIndex, TagFlags};
 use ontol_macros::OntolDebug;

--- a/ontol/ontol-runtime/src/ontology.rs
+++ b/ontol/ontol-runtime/src/ontology.rs
@@ -8,10 +8,9 @@ use aspects::{
     OntologyAspects, SerdeAspect,
 };
 use domain::EdgeInfo;
-use ontol_core::{debug::OntolFormatter, tag::DomainIndex};
+use ontol_core::{DomainId, debug::OntolFormatter, tag::DomainIndex};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
-use ulid::Ulid;
 
 use crate::{
     DefId, MapKey, PropId,
@@ -121,12 +120,12 @@ impl Ontology {
         self.data.defs.domain_by_index(index)
     }
 
-    pub fn domain_by_id(&self, domain_id: Ulid) -> Option<&Domain> {
+    pub fn domain_by_id(&self, id: DomainId) -> Option<&Domain> {
         self.data
             .defs
             .domains
             .iter()
-            .find(|(_, domain)| domain.domain_id().ulid == domain_id)
+            .find(|(_, domain)| domain.domain_id().id == id)
             .map(|(_, domain)| domain)
     }
 

--- a/ontol/ontol-runtime/src/ontology/domain.rs
+++ b/ontol/ontol-runtime/src/ontology/domain.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 
 use fnv::FnvHashMap;
 use ontol_core::{
-    DomainId, TopologyGeneration,
+    OntologyDomainId, TopologyGeneration,
     vec_map::{VecMap, VecMapKey},
 };
 use ontol_macros::OntolDebug;
@@ -25,7 +25,7 @@ use super::{
 /// A domain in the ONTOL ontology.
 #[derive(Serialize, Deserialize)]
 pub struct Domain {
-    domain_id: DomainId,
+    domain_id: OntologyDomainId,
     def_id: DefId,
 
     unique_name: TextConstant,
@@ -45,7 +45,7 @@ impl VecMapKey for DefTag {
 
 impl Domain {
     pub fn new(
-        domain_id: DomainId,
+        domain_id: OntologyDomainId,
         def_id: DefId,
         unique_name: TextConstant,
         generation: TopologyGeneration,
@@ -59,7 +59,7 @@ impl Domain {
         }
     }
 
-    pub fn domain_id(&self) -> &DomainId {
+    pub fn domain_id(&self) -> &OntologyDomainId {
         &self.domain_id
     }
 

--- a/ontol/ontol-test-utils/src/def_binding.rs
+++ b/ontol/ontol-test-utils/src/def_binding.rs
@@ -125,7 +125,7 @@ impl<'on> DefBinding<'on> {
             .domain_by_index(self.def.id.domain_index())
             .unwrap();
 
-        format!("{}:{}", domain.domain_id().ulid, self.def.id.1)
+        format!("{}:{}", domain.domain_id().id, self.def.id.1)
     }
 
     #[track_caller]


### PR DESCRIPTION
This is a feature that will only when using ontol-log. Different ontol files associated with a common log will be defined as _subdomains_. A DomainId now consists of an ULID and a numeric subdomain tag. In the old orthodox mode the subdomain tag is always 0.