### PR TITLE
feat: transient and persistent domain definitions

### DIFF
--- a/domain-engine/domain-engine-core/src/crdt_util.rs
+++ b/domain-engine/domain-engine-core/src/crdt_util.rs
@@ -191,7 +191,7 @@ impl<'e> MakeStorable<'e> {
 
         let domain = self.defs.domain_by_index(def_id.domain_index()).unwrap();
         let domain_id = domain.domain_id().id;
-        let def_tag = def_id.1;
+        let def_tag = def_id.tag();
         let prop_tag = prop_id.1.0;
 
         format!("{domain_id}_{def_tag}_{prop_tag}")
@@ -386,6 +386,9 @@ impl<'a> AutomergeDeserializer<'a> {
             return Err(FromCrdtError::Datastore("domain not in the ontology"));
         };
 
-        Ok(PropId(DefId(domain_index, def_tag), DefPropTag(prop_tag)))
+        Ok(PropId(
+            DefId::new_persistent(domain_index, def_tag),
+            DefPropTag(prop_tag),
+        ))
     }
 }

--- a/domain-engine/domain-engine-core/tests/integration/data_store_tests.rs
+++ b/domain-engine/domain-engine-core/tests/integration/data_store_tests.rs
@@ -243,8 +243,7 @@ async fn test_conduit_db_id_generation(ds: &str) {
 
     expect_eq!(
         actual = format!("{:?}", explicit_user_id),
-        expected =
-            "OctetSequence(67e5504410b1426f9247bb680e5fe0c8, tag(def@1:1, Some(TagFlags(0x0))))"
+        expected = "OctetSequence(67e5504410b1426f9247bb680e5fe0c8, tag(def@1:1, Some(TagFlags(PERSISTENT))))"
     );
 
     let article_id: Uuid = data_store_util::insert_entity_select_entityid(

--- a/domain-engine/domain-engine-graphql/src/ontology/gql_def.rs
+++ b/domain-engine/domain-engine-graphql/src/ontology/gql_def.rs
@@ -60,16 +60,12 @@ impl Def {
     /// The identifier of this def.
     /// The ID is unique only within this particular ontology.
     fn id(&self, ctx: &OntologyCtx) -> gql_id::DefId {
-        let domain = ctx.domain_by_index(self.id.domain_index()).unwrap();
-        gql_id::DefId {
-            domain_id: domain.domain_id().id,
-            def_tag: self.id.1,
-        }
+        super::gql_id::DefId::new(self.id, ctx)
     }
 
     /// The tag of this def, unique within its domain.
     fn tag(&self) -> i32 {
-        self.id.1.into()
+        self.id.tag().into()
     }
 
     /// The domain of this Def

--- a/domain-engine/domain-engine-graphql/src/ontology/gql_query.rs
+++ b/domain-engine/domain-engine-graphql/src/ontology/gql_query.rs
@@ -379,6 +379,7 @@ impl Query {
                         def_id: gql_id::DefId {
                             domain_id: f.facet.domain_id,
                             def_tag: f.facet.def_tag.unwrap(),
+                            persistent: true,
                         },
                         count: f.count.try_into().unwrap_or(i32::MAX),
                     })

--- a/domain-engine/domain-engine-graphql/src/ontology/gql_value.rs
+++ b/domain-engine/domain-engine-graphql/src/ontology/gql_value.rs
@@ -95,11 +95,8 @@ pub fn write_ontol_scalar(
 ) -> juniper::FieldResult<()> {
     let def_id = value.type_def_id();
     if cfg.with_def_id {
-        if let Some(domain) = ctx.domain_by_index(def_id.0) {
-            let gql_def_id = gql_id::DefId {
-                domain_id: domain.domain_id().id,
-                def_tag: def_id.1,
-            };
+        if let Some(_domain) = ctx.domain_by_index(def_id.domain_index()) {
+            let gql_def_id = gql_id::DefId::new(def_id, ctx);
 
             put_string(gobj, DEF_ID, format!("{gql_def_id}"));
         }

--- a/domain-engine/domain-engine-graphql/tests/graphql-integration/test_graphql_ontology.rs
+++ b/domain-engine/domain-engine-graphql/tests/graphql-integration/test_graphql_ontology.rs
@@ -36,11 +36,16 @@ fn expected_defs() -> juniper::Value<GqlScalar> {
     }
 
     impl Builder {
-        fn add(&mut self, ident: &str, kind: &str) {
+        fn add(&mut self, ident: &str, kind: &str, persistent: bool) {
             let mut obj = juniper::Object::with_capacity(2);
             obj.add_field(
                 "id",
-                format!("01GNYFZP30ED0EZ1579TH0D55P§0:{}", self.next_tag).into(),
+                format!(
+                    "{}01GNYFZP30ED0EZ1579TH0D55P§0:{}",
+                    if persistent { "" } else { "~" },
+                    self.next_tag
+                )
+                .into(),
             );
             obj.add_field("ident", ident.into());
             obj.add_field("kind", kind.into());
@@ -49,59 +54,73 @@ fn expected_defs() -> juniper::Value<GqlScalar> {
             self.list.push(juniper::Value::Object(obj));
         }
 
+        fn add_persistent(&mut self, ident: &str, kind: &str) {
+            self.add(ident, kind, true);
+        }
+
+        fn add_transient(&mut self, ident: &str, kind: &str) {
+            self.add(ident, kind, false);
+        }
+
         fn skip(&mut self, n: usize) {
             self.next_tag += n;
+        }
+
+        fn reset(&mut self) {
+            self.next_tag = 0;
         }
     }
 
     let mut b = Builder::default();
 
-    b.add("ontol", "DOMAIN");
+    b.add_persistent("ontol", "DOMAIN");
     b.skip(1);
-    b.add("false", "DATA");
-    b.add("true", "DATA");
-    b.add("boolean", "DATA");
+    b.add_persistent("false", "DATA");
+    b.add_persistent("true", "DATA");
+    b.add_persistent("boolean", "DATA");
     b.skip(2);
-    b.add("number", "DATA");
-    b.add("integer", "DATA");
-    b.add("i64", "DATA");
-    b.add("float", "DATA");
-    b.add("f32", "DATA");
-    b.add("f64", "DATA");
-    b.add("serial", "DATA");
-    b.add("text", "DATA");
-    b.add("octets", "DATA");
-    b.add("vertex", "DATA");
-    b.add("uuid", "DATA");
-    b.add("ulid", "DATA");
-    b.add("datetime", "DATA");
+    b.add_persistent("number", "DATA");
+    b.add_persistent("integer", "DATA");
+    b.add_persistent("i64", "DATA");
+    b.add_persistent("float", "DATA");
+    b.add_persistent("f32", "DATA");
+    b.add_persistent("f64", "DATA");
+    b.add_persistent("serial", "DATA");
+    b.add_persistent("text", "DATA");
+    b.add_persistent("octets", "DATA");
+    b.add_persistent("vertex", "DATA");
+    b.add_persistent("uuid", "DATA");
+    b.add_persistent("ulid", "DATA");
+    b.add_persistent("datetime", "DATA");
     b.skip(3);
-    b.add("is", "RELATION");
+    b.add_persistent("is", "RELATION");
     b.skip(3);
-    b.add("store_key", "RELATION");
-    b.add("min", "RELATION");
-    b.add("max", "RELATION");
-    b.add("default", "RELATION");
-    b.add("gen", "RELATION");
-    b.add("order", "RELATION");
-    b.add("direction", "RELATION");
-    b.add("example", "RELATION");
+    b.add_persistent("store_key", "RELATION");
+    b.add_persistent("min", "RELATION");
+    b.add_persistent("max", "RELATION");
+    b.add_persistent("default", "RELATION");
+    b.add_persistent("gen", "RELATION");
+    b.add_persistent("order", "RELATION");
+    b.add_persistent("direction", "RELATION");
+    b.add_persistent("example", "RELATION");
     b.skip(2);
-    b.add("ascending", "DATA");
-    b.add("descending", "DATA");
-    b.add("auto", "GENERATOR");
-    b.add("create_time", "GENERATOR");
-    b.add("update_time", "GENERATOR");
-    b.add("format", "DATA");
+    b.add_persistent("ascending", "DATA");
+    b.add_persistent("descending", "DATA");
+    b.add_persistent("auto", "GENERATOR");
+    b.add_persistent("create_time", "GENERATOR");
+    b.add_persistent("update_time", "GENERATOR");
+    b.add_persistent("format", "DATA");
     b.skip(2);
-    b.add("repr", "RELATION");
-    b.add("crdt", "GENERATOR");
+    b.add_persistent("repr", "RELATION");
+    b.add_persistent("crdt", "GENERATOR");
+
+    b.reset();
     b.skip(6);
-    b.add("+", "FUNCTION");
-    b.add("-", "FUNCTION");
-    b.add("*", "FUNCTION");
-    b.add("/", "FUNCTION");
-    b.add("append", "FUNCTION");
+    b.add_transient("+", "FUNCTION");
+    b.add_transient("-", "FUNCTION");
+    b.add_transient("*", "FUNCTION");
+    b.add_transient("/", "FUNCTION");
+    b.add_transient("append", "FUNCTION");
 
     juniper::Value::List(b.list)
 }

--- a/domain-engine/domain-engine-store-pg/src/migrate/mod.rs
+++ b/domain-engine/domain-engine-store-pg/src/migrate/mod.rs
@@ -245,7 +245,7 @@ pub async fn migrate_ontology(
                     .count();
 
                 if unique_count > 1 {
-                    let edge_id = DefId(*domain_index, *edge_tag);
+                    let edge_id = DefId::new_persistent(*domain_index, *edge_tag);
                     return Err(anyhow!(
                         "edge {edge_id:?} has more than one unique cardinal, which doesn't work yet"
                     ));

--- a/domain-engine/domain-engine-store-pg/src/migrate/read_registry.rs
+++ b/domain-engine/domain-engine-store-pg/src/migrate/read_registry.rs
@@ -121,7 +121,7 @@ pub async fn read_registry(
         match table_type {
             PgDomainTableType::Vertex => {
                 let def_domain_index = domain_index_by_key.get(&def_domain_key).unwrap();
-                let def_id = DefId(*def_domain_index, def_tag);
+                let def_id = DefId::new_persistent(*def_domain_index, def_tag);
                 owner_pg_domain.datatables.insert(def_id, pg_table);
                 table_by_key.insert(key, TableRef::Vertex(owner_domain_index, def_id));
             }
@@ -129,7 +129,7 @@ pub async fn read_registry(
                 owner_pg_domain.edgetables.insert(def_tag, pg_table);
                 table_by_key.insert(
                     key,
-                    TableRef::Edge(EdgeId(DefId(owner_domain_index, def_tag))),
+                    TableRef::Edge(EdgeId(DefId::new_persistent(owner_domain_index, def_tag))),
                 );
             }
         }
@@ -178,7 +178,7 @@ pub async fn read_registry(
             }
             Some(TableRef::Edge(edge_id)) => {
                 let pg_domain = ctx.domains.get_mut(&edge_id.domain_index()).unwrap();
-                let pg_table = pg_domain.edgetables.get_mut(&edge_id.def_id().1).unwrap();
+                let pg_table = pg_domain.edgetables.get_mut(&edge_id.def_id().tag()).unwrap();
 
                 pg_table.properties.insert(prop_tag, pg_property);
             }
@@ -204,7 +204,7 @@ pub async fn read_registry(
         let Some(domain_index) = domain_index_by_key.get(&def_domain_key).copied() else {
             continue;
         };
-        let index_def_id = DefId(domain_index, def_tag);
+        let index_def_id = DefId::new_persistent(domain_index, def_tag);
 
         match table_by_key.get(&domaintable_key) {
             Some(TableRef::Vertex(owner_domain_index, def_id)) => {
@@ -265,7 +265,10 @@ pub async fn read_registry(
         };
 
         let pg_domain = ctx.domains.get_mut(&edge_id.domain_index()).unwrap();
-        let pg_table = pg_domain.edgetables.get_mut(&edge_id.def_id().1).unwrap();
+        let pg_table = pg_domain
+            .edgetables
+            .get_mut(&edge_id.def_id().tag())
+            .unwrap();
 
         pg_table.edge_cardinals.insert(
             CardinalIdx(ordinal.try_into()?),

--- a/domain-engine/domain-engine-store-pg/src/migrate/steps.rs
+++ b/domain-engine/domain-engine-store-pg/src/migrate/steps.rs
@@ -222,7 +222,7 @@ async fn migrate_domain_edges_steps(
     let pg_domain = ctx.domains.get_mut(&domain_index).unwrap();
     let mut param_def_ids: Vec<(EdgeId, DefId)> = vec![];
     for (edge_id, edge_info) in domain.edges() {
-        let edge_tag = edge_id.1;
+        let edge_tag = edge_id.tag();
         let ident = &ontology_defs[edge_info.ident];
         let table_name = format!("e_{ident}").into_boxed_str();
 

--- a/domain-engine/domain-engine-store-pg/src/pg_model.rs
+++ b/domain-engine/domain-engine-store-pg/src/pg_model.rs
@@ -34,7 +34,7 @@ pub struct EdgeId(pub DefId);
 impl EdgeId {
     #[inline]
     pub fn domain_index(&self) -> DomainIndex {
-        self.0.0
+        self.0.domain_index()
     }
 
     #[inline]
@@ -86,7 +86,7 @@ impl PgModel {
 
     pub fn stable_property_index(&self, prop_id: PropId) -> Option<u32> {
         let def_id = prop_id.0;
-        let pg_domain = self.domains.get(&def_id.0)?;
+        let pg_domain = self.domains.get(&def_id.domain_index())?;
         let pg_table = pg_domain.datatables.get(&def_id)?;
         let pg_property = pg_table.properties.get(&prop_id.1)?;
 
@@ -141,7 +141,7 @@ impl PgModel {
     pub fn find_edgetable(&self, edge_id: &EdgeId) -> Option<&PgTable> {
         self.domains
             .get(&edge_id.domain_index())
-            .and_then(|pg_domain| pg_domain.edgetables.get(&edge_id.def_id().1))
+            .and_then(|pg_domain| pg_domain.edgetables.get(&edge_id.def_id().tag()))
     }
 
     pub fn edgetable(&self, edge_id: &EdgeId) -> DomainResult<&PgTable> {
@@ -262,7 +262,7 @@ impl PgDomain {
     pub fn get_table(&self, id: &PgTableIdUnion) -> Option<&PgTable> {
         match id {
             PgTableIdUnion::Def(def_id) => self.datatables.get(def_id),
-            PgTableIdUnion::Edge(edge_id) => self.edgetables.get(&edge_id.def_id().1),
+            PgTableIdUnion::Edge(edge_id) => self.edgetables.get(&edge_id.def_id().tag()),
         }
     }
 }

--- a/domain-engine/domain-engine-store-pg/src/transact/insert.rs
+++ b/domain-engine/domain-engine-store-pg/src/transact/insert.rs
@@ -376,7 +376,7 @@ impl<'a> TransactCtx<'a> {
 
             Ok(())
         } else {
-            let domain_index = value_def_id.0;
+            let domain_index = value_def_id.domain_index();
             let def_id = value_def_id;
 
             let cache_key = (InsertMode::Insert, domain_index, def_id);

--- a/domain-engine/domain-engine-tantivy/src/document.rs
+++ b/domain-engine/domain-engine-tantivy/src/document.rs
@@ -50,7 +50,10 @@ impl std::error::Error for DocError {}
 impl IndexingContext {
     pub fn make_vertex_doc(&self, vertex: Value) -> Result<Doc, DocError> {
         let def_id = vertex.type_def_id();
-        let domain = self.ontology.domain_by_index(def_id.0).unwrap();
+        let domain = self
+            .ontology
+            .domain_by_index(def_id.domain_index())
+            .unwrap();
 
         if !domain.domain_id().stable {
             return Err(DocError::UnstableDomain);
@@ -106,7 +109,8 @@ impl IndexingContext {
         doc.add_field_value(
             self.schema.facet,
             OwnedValue::Facet(
-                Facet::from_text(&format!("/def/{}:{}", domain.domain_id().id, def_id.1)).unwrap(),
+                Facet::from_text(&format!("/def/{}:{}", domain.domain_id().id, def_id.tag()))
+                    .unwrap(),
             ),
         );
         doc.add_field_value(

--- a/domain-engine/domain-engine-tantivy/src/search.rs
+++ b/domain-engine/domain-engine-tantivy/src/search.rs
@@ -300,7 +300,10 @@ impl TantivyDataStoreLayer {
                 .parse()
                 .map_err(|_| SearchError::DocInvalidDomainDefId)?;
 
-            return Ok(Some(DefId(domain.def_id().domain_index(), def_tag)));
+            return Ok(Some(DefId::new_persistent(
+                domain.def_id().domain_index(),
+                def_tag,
+            )));
         }
 
         Err(SearchError::DocMissingDomainDefId.into())

--- a/ontol/ontol-compiler/src/codegen/auto_map.rs
+++ b/ontol/ontol-compiler/src/codegen/auto_map.rs
@@ -48,9 +48,11 @@ pub fn autogenerate_mapping<'m>(
 
             Some(ExplicitMapCodegenTask {
                 ontol_map: Some(OntolMap {
-                    map_def_id: compiler
-                        .defs
-                        .add_def(DefKind::AutoMapping, domain_index, NO_SPAN),
+                    map_def_id: compiler.defs.add_persistent_def(
+                        DefKind::AutoMapping,
+                        domain_index,
+                        NO_SPAN,
+                    ),
                     arms: OntolMapArms::Patterns(arms),
                     span: NO_SPAN,
                 }),
@@ -64,9 +66,11 @@ pub fn autogenerate_mapping<'m>(
 
             Some(ExplicitMapCodegenTask {
                 ontol_map: Some(OntolMap {
-                    map_def_id: compiler
-                        .defs
-                        .add_def(DefKind::AutoMapping, domain_index, NO_SPAN),
+                    map_def_id: compiler.defs.add_persistent_def(
+                        DefKind::AutoMapping,
+                        domain_index,
+                        NO_SPAN,
+                    ),
                     arms: OntolMapArms::Patterns([fmt_node, transparent_node]),
                     span: NO_SPAN,
                 }),
@@ -80,9 +84,11 @@ pub fn autogenerate_mapping<'m>(
 
             Some(ExplicitMapCodegenTask {
                 ontol_map: Some(OntolMap {
-                    map_def_id: compiler
-                        .defs
-                        .add_def(DefKind::AutoMapping, domain_index, NO_SPAN),
+                    map_def_id: compiler.defs.add_persistent_def(
+                        DefKind::AutoMapping,
+                        domain_index,
+                        NO_SPAN,
+                    ),
                     arms: OntolMapArms::Patterns([transparent_node, fmt_node]),
                     span: NO_SPAN,
                 }),
@@ -164,7 +170,7 @@ pub fn autogenerate_mapping<'m>(
 
                 return Some(ExplicitMapCodegenTask {
                     ontol_map: Some(OntolMap {
-                        map_def_id: compiler.defs.add_def(
+                        map_def_id: compiler.defs.add_persistent_def(
                             DefKind::AutoMapping,
                             domain_index,
                             NO_SPAN,
@@ -195,7 +201,7 @@ pub fn autogenerate_mapping<'m>(
 
                     Some(ExplicitMapCodegenTask {
                         ontol_map: Some(OntolMap {
-                            map_def_id: compiler.defs.add_def(
+                            map_def_id: compiler.defs.add_persistent_def(
                                 DefKind::AutoMapping,
                                 domain_index,
                                 NO_SPAN,

--- a/ontol/ontol-compiler/src/compile_domain.rs
+++ b/ontol/ontol-compiler/src/compile_domain.rs
@@ -63,7 +63,7 @@ impl Compiler<'_> {
             .report(self);
         }
 
-        let domain_def_id = self.defs.alloc_def_id(domain_index);
+        let domain_def_id = self.defs.alloc_persistent_def_id(domain_index);
         self.define_domain(domain_def_id);
 
         self.loaded.by_url.insert(parsed.url.clone(), domain_def_id);
@@ -141,8 +141,8 @@ impl Compiler<'_> {
 
         // handle relationships in macros first, they have to be ready before other relationships
         for macro_def_id in macro_defs {
-            if let Some(pkg_rels) = outcome.rels.get_mut(&macro_def_id.0) {
-                if let Some(macro_rels) = pkg_rels.remove(&macro_def_id.1) {
+            if let Some(pkg_rels) = outcome.rels.get_mut(&macro_def_id.domain_index()) {
+                if let Some(macro_rels) = pkg_rels.remove(&macro_def_id.tag()) {
                     let mut macro_items: Vec<MacroItem> = vec![];
 
                     for (rel_tag, relationship, span, docs) in macro_rels {
@@ -197,7 +197,7 @@ impl Compiler<'_> {
             for (domain_index, rel_map) in outcome.rels {
                 for (def_tag, rels) in rel_map {
                     for (rel_tag, relationship, span, docs) in rels {
-                        let rel_id = RelId(DefId(domain_index, def_tag), rel_tag);
+                        let rel_id = RelId(DefId::new_persistent(domain_index, def_tag), rel_tag);
                         self.rel_ctx.commit_rel(rel_id, relationship, span);
 
                         if let Some(docs) = docs {

--- a/ontol/ontol-compiler/src/entity/check_entity.rs
+++ b/ontol/ontol-compiler/src/entity/check_entity.rs
@@ -30,7 +30,7 @@ impl Compiler<'_> {
                 }
             } else {
                 let entity_span = self.defs.def_span(def_id);
-                let order_union = self.defs.add_def(
+                let order_union = self.defs.add_persistent_def(
                     DefKind::Type(TypeDef {
                         ident: None,
                         rel_type_for: None,

--- a/ontol/ontol-compiler/src/interface/graphql/graphql_namespace.rs
+++ b/ontol/ontol-compiler/src/interface/graphql/graphql_namespace.rs
@@ -119,7 +119,7 @@ impl<'o> GraphqlNamespace<'o> {
 
         if let Some(domain_disambiguation) = &self.domain_disambiguation {
             if let Some(def_id) = elements.iter().find_map(|elem| elem.def_id()) {
-                let domain_index = def_id.0;
+                let domain_index = def_id.domain_index();
                 if domain_index != domain_disambiguation.root_domain {
                     output.push('_');
                     if let Some(domain) = domain_disambiguation
@@ -225,7 +225,11 @@ impl ProcessName for Typename<'_, '_> {
 fn format_name_pre_rewrite<'k>(def_id: DefId, kind: &'k DefKind) -> Cow<'k, str> {
     match kind.opt_identifier() {
         Some(name) => name,
-        None => Cow::Owned(format!("_anon{}_{}", def_id.0.index(), def_id.1)),
+        None => Cow::Owned(format!(
+            "_anon{}_{}",
+            def_id.domain_index().index(),
+            def_id.tag()
+        )),
     }
 }
 

--- a/ontol/ontol-compiler/src/lowering/context.rs
+++ b/ontol/ontol-compiler/src/lowering/context.rs
@@ -71,12 +71,12 @@ impl LoweringOutcome {
         span: SourceSpan,
         docs: Option<ArcStr>,
     ) {
-        let RelId(DefId(domain_index, def_tag), rel_tag) = rel_id;
+        let RelId(def_id, rel_tag) = rel_id;
 
         self.rels
-            .entry(domain_index)
+            .entry(def_id.domain_index())
             .or_default()
-            .entry(def_tag)
+            .entry(def_id.tag())
             .or_default()
             .push((rel_tag, relationship, span, docs));
     }
@@ -370,7 +370,10 @@ impl<'m> LoweringCtx<'_, 'm> {
                 }
             }
             Entry::Vacant(vacant) => {
-                let def_id = self.compiler.defs.alloc_def_id(self.domain_index);
+                let def_id = self
+                    .compiler
+                    .defs
+                    .alloc_persistent_def_id(self.domain_index);
                 vacant.insert(def_id);
                 Ok((def_id, Coinage::New, ident))
             }
@@ -378,14 +381,20 @@ impl<'m> LoweringCtx<'_, 'm> {
     }
 
     pub fn define_anonymous_type(&mut self, type_def: TypeDef<'m>, span: U32Span) -> DefId {
-        let anonymous_def_id = self.compiler.defs.alloc_def_id(self.domain_index);
+        let anonymous_def_id = self
+            .compiler
+            .defs
+            .alloc_persistent_def_id(self.domain_index);
         self.set_def_kind(anonymous_def_id, DefKind::Type(type_def), span);
         debug!("{anonymous_def_id:?}: <anonymous>");
         anonymous_def_id
     }
 
     pub fn define_anonymous(&mut self, kind: DefKind<'m>, span: U32Span) -> DefId {
-        let def_id = self.compiler.defs.alloc_def_id(self.domain_index);
+        let def_id = self
+            .compiler
+            .defs
+            .alloc_persistent_def_id(self.domain_index);
         self.set_def_kind(def_id, kind, span);
         def_id
     }

--- a/ontol/ontol-compiler/src/lowering/lower_map.rs
+++ b/ontol/ontol-compiler/src/lowering/lower_map.rs
@@ -55,7 +55,10 @@ impl<V: NodeView> CstLowering<'_, '_, V> {
                 (def_id, Some(ident))
             }
             None => (
-                self.ctx.compiler.defs.alloc_def_id(self.ctx.domain_index),
+                self.ctx
+                    .compiler
+                    .defs
+                    .alloc_persistent_def_id(self.ctx.domain_index),
                 None,
             ),
         };

--- a/ontol/ontol-compiler/src/lowering/lower_misc.rs
+++ b/ontol/ontol-compiler/src/lowering/lower_misc.rs
@@ -122,7 +122,7 @@ impl<V: NodeView> CstLowering<'_, '_, V> {
                 match token.kind() {
                     Kind::Number => {
                         let lit = self.ctx.compiler.str_ctx.intern(token.slice());
-                        let def_id = self.ctx.compiler.defs.add_def(
+                        let def_id = self.ctx.compiler.defs.add_transient_def(
                             DefKind::NumberLiteral(lit),
                             DomainIndex::ontol(),
                             self.ctx.source_span(token.span()),
@@ -212,7 +212,11 @@ impl<V: NodeView> CstLowering<'_, '_, V> {
                 if let Some(union_def_id) = self.ctx.anonymous_unions.get(&members) {
                     Some(*union_def_id)
                 } else {
-                    let union_def_id = self.ctx.compiler.defs.alloc_def_id(self.ctx.domain_index);
+                    let union_def_id = self
+                        .ctx
+                        .compiler
+                        .defs
+                        .alloc_persistent_def_id(self.ctx.domain_index);
                     self.ctx.set_def_kind(
                         union_def_id,
                         DefKind::InlineUnion(members.clone()),

--- a/ontol/ontol-compiler/src/ontol_domain.rs
+++ b/ontol/ontol-compiler/src/ontol_domain.rs
@@ -277,7 +277,7 @@ impl<'m> Compiler<'m> {
         param: DefId,
         literal: &'static str,
     ) {
-        let literal = self.defs.add_def(
+        let literal = self.defs.add_transient_def(
             DefKind::NumberLiteral(literal),
             DomainIndex::ontol(),
             NO_SPAN,
@@ -373,7 +373,7 @@ impl<'m> Compiler<'m> {
     }
 
     fn def_proc(&mut self, ident: &'static str, def_kind: DefKind<'m>, ty: TypeRef<'m>) -> DefId {
-        let def_id = self.add_named_def(
+        let def_id = self.add_named_transient_def(
             ident,
             Space::Def,
             def_kind,

--- a/ontol/ontol-compiler/src/type_check/check_def.rs
+++ b/ontol/ontol-compiler/src/type_check/check_def.rs
@@ -31,7 +31,7 @@ impl<'m> TypeCheck<'_, 'm> {
             .defs
             .table
             .get(&def_id)
-            .expect("BUG: definition not found");
+            .unwrap_or_else(|| panic!("BUG: definition {def_id:?} not found"));
 
         match &def.kind {
             DefKind::Type(TypeDef {

--- a/ontol/ontol-core/src/url.rs
+++ b/ontol/ontol-core/src/url.rs
@@ -30,8 +30,8 @@ impl DomainUrl {
     }
 
     pub fn short_name(&self) -> &str {
-        if let Some(segments) = self.0.path_segments() {
-            if let Some(last) = segments.last() {
+        if let Some(mut segments) = self.0.path_segments() {
+            if let Some(last) = segments.next_back() {
                 return last;
             }
         }
@@ -53,8 +53,8 @@ impl DomainUrl {
 
                     segments.pop();
 
-                    if let Some(orig_segments) = other.0.path_segments() {
-                        if let Some(yo) = orig_segments.last() {
+                    if let Some(mut orig_segments) = other.0.path_segments() {
+                        if let Some(yo) = orig_segments.next_back() {
                             segments.push(yo);
                         }
                     }

--- a/ontol/ontol-examples/src/lib.rs
+++ b/ontol/ontol-examples/src/lib.rs
@@ -224,8 +224,8 @@ impl AsAtlas for DomainUrl {
         if self.url().scheme() == "atlas" {
             self.clone()
         } else {
-            let path_segments = self.url().path_segments().unwrap();
-            let file_name = path_segments.last().unwrap();
+            let mut path_segments = self.url().path_segments().unwrap();
+            let file_name = path_segments.next_back().unwrap();
 
             DomainUrl::new(
                 Url::parse(&format!("atlas:/protojour/{bundle_name}/{file_name}")).unwrap(),

--- a/ontol/ontol-hir/src/parse.rs
+++ b/ontol/ontol-hir/src/parse.rs
@@ -540,7 +540,7 @@ fn parse_def_id(next: &str) -> ParseResult<DefId> {
         panic!("invalid domain index");
     };
 
-    Ok((DefId(domain_index, tag as u16), next_outer))
+    Ok((DefId::new_persistent(domain_index, tag as u16), next_outer))
 }
 
 fn parse_i64(next: &str) -> ParseResult<i64> {

--- a/ontol/ontol-runtime/src/lib.rs
+++ b/ontol/ontol-runtime/src/lib.rs
@@ -8,6 +8,7 @@ use indexmap::IndexMap;
 pub use ontol_core::DomainId;
 use ontol_core::impl_ontol_debug;
 pub use ontol_core::tag::{DomainIndex, TagFlags};
+use ontol_core::vec_map::VecMapKey;
 use ontol_macros::OntolDebug;
 use smallvec::SmallVec;
 
@@ -36,17 +37,79 @@ extern crate self as ontol_runtime;
 
 /// One definition inside some ONTOL domain.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-pub struct DefId(pub DomainIndex, pub u16);
+pub struct DefId {
+    domain_index: u16,
+    tag: u16,
+}
 
 impl DefId {
-    pub fn domain_index(&self) -> DomainIndex {
-        self.0
+    pub const fn new_persistent(domain_index: DomainIndex, tag: u16) -> Self {
+        Self {
+            domain_index: domain_index.index() | TagFlags::PERSISTENT.bits(),
+            tag,
+        }
+    }
+
+    pub const fn new_transient(domain_index: DomainIndex, tag: u16) -> Self {
+        Self {
+            domain_index: domain_index.index(),
+            tag,
+        }
+    }
+
+    #[inline]
+    pub const fn domain_index(&self) -> DomainIndex {
+        DomainIndex::from_u16_and_mask(self.domain_index, TagFlags::PKG_MASK)
+    }
+
+    #[inline]
+    pub const fn domain_index_with_persistent_flag(&self) -> DomainIndex {
+        DomainIndex::from_u16_and_mask(
+            self.domain_index,
+            TagFlags::PKG_MASK.union(TagFlags::PERSISTENT),
+        )
+    }
+
+    #[inline]
+    pub const fn tag(&self) -> u16 {
+        self.tag
+    }
+
+    #[inline]
+    pub const fn is_persistent(&self) -> bool {
+        (self.domain_index & TagFlags::PERSISTENT.bits()) != 0
+    }
+
+    #[inline]
+    pub fn fmt_sep_char(&self) -> char {
+        if self.is_persistent() { '@' } else { '~' }
+    }
+}
+
+impl From<ValueTag> for DefId {
+    fn from(value: ValueTag) -> Self {
+        value.def_id()
     }
 }
 
 impl Debug for DefId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "def@{}:{}", self.0.index(), self.1)
+        write!(
+            f,
+            "def{sep}{}:{}",
+            self.domain_index().index(),
+            self.tag,
+            sep = self.fmt_sep_char()
+        )
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub struct DefTag(pub u16);
+
+impl VecMapKey for DefTag {
+    fn index(&self) -> usize {
+        self.0 as usize
     }
 }
 
@@ -57,16 +120,28 @@ impl FromStr for DefId {
     type Err = ParseDefIdError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (domain_idx, def_tag) = s
-            .strip_prefix("def@")
-            .and_then(|s| s.split_once(':'))
-            .ok_or(ParseDefIdError)?;
+        let s = s.strip_prefix("def").ok_or(ParseDefIdError)?;
+        let mut persistent = false;
+        let s = if let Some(s) = s.strip_prefix("@") {
+            persistent = true;
+            s
+        } else if let Some(s) = s.strip_prefix("~") {
+            s
+        } else {
+            return Err(ParseDefIdError);
+        };
+
+        let (domain_idx, def_tag) = s.split_once(':').ok_or(ParseDefIdError)?;
+
         let domain_idx = domain_idx.parse::<u16>().map_err(|_| ParseDefIdError)?;
         let def_tag = def_tag.parse::<u16>().map_err(|_| ParseDefIdError)?;
-        Ok(DefId(
-            DomainIndex::from_u16_and_mask(domain_idx, TagFlags::PKG_MASK),
-            def_tag,
-        ))
+        let domain_index = DomainIndex::from_u16_and_mask(domain_idx, TagFlags::PKG_MASK);
+
+        Ok(if persistent {
+            DefId::new_persistent(domain_index, def_tag)
+        } else {
+            DefId::new_transient(domain_index, def_tag)
+        })
     }
 }
 
@@ -75,11 +150,12 @@ impl_ontol_debug!(DefId);
 impl DefId {
     #[inline]
     pub const fn unit() -> Self {
-        DefId(DomainIndex::ontol(), OntolDefTag::Unit as u16)
+        DefId::new_persistent(DomainIndex::ontol(), OntolDefTag::Unit as u16)
     }
 }
 
 pub use ontol_core::tag::OntolDefTag;
+use value::ValueTag;
 
 pub trait OntolDefTagExt {
     fn def_id(self) -> DefId;
@@ -89,7 +165,7 @@ pub trait OntolDefTagExt {
 
 impl OntolDefTagExt for OntolDefTag {
     fn def_id(self) -> DefId {
-        DefId(DomainIndex::ontol(), self as u16)
+        DefId::new_persistent(DomainIndex::ontol(), self as u16)
     }
 
     fn prop_id_0(self) -> PropId {
@@ -190,13 +266,27 @@ impl PropId {
 /// This forces single-line output even when pretty-printed
 impl ::std::fmt::Debug for PropId {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "p@{}:{}:{}", self.0.0.index(), self.0.1, self.1.0)
+        write!(
+            f,
+            "p{sep}{}:{}:{}",
+            self.0.domain_index().index(),
+            self.0.tag(),
+            self.1.0,
+            sep = self.0.fmt_sep_char(),
+        )
     }
 }
 
 impl ::std::fmt::Display for PropId {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "p@{}:{}:{}", self.0.0.index(), self.0.1, self.1.0)
+        write!(
+            f,
+            "p{sep}{}:{}:{}",
+            self.0.domain_index().index(),
+            self.0.tag(),
+            self.1.0,
+            sep = self.0.fmt_sep_char(),
+        )
     }
 }
 
@@ -206,21 +296,37 @@ impl FromStr for PropId {
     type Err = ();
 
     fn from_str(mut s: &str) -> Result<Self, Self::Err> {
-        s = s.strip_prefix("p@").ok_or(())?;
+        s = s.strip_prefix("p").ok_or(())?;
+        let mut persistent = false;
+        s = if let Some(s) = s.strip_prefix("@") {
+            persistent = true;
+            s
+        } else if let Some(s) = s.strip_prefix("~") {
+            s
+        } else {
+            return Err(());
+        };
 
         let mut iterator = s.split(':');
         let domain_idx = DomainIndex::from_u16_and_mask(
             iterator.next().ok_or(())?.parse().map_err(|_| ())?,
             TagFlags::PKG_MASK,
         );
-        let def_idx: u16 = iterator.next().ok_or(())?.parse().map_err(|_| ())?;
+        let def_tag: u16 = iterator.next().ok_or(())?.parse().map_err(|_| ())?;
         let def_rel_tag: u16 = iterator.next().ok_or(())?.parse().map_err(|_| ())?;
 
         if iterator.next().is_some() {
             return Err(());
         }
 
-        Ok(PropId(DefId(domain_idx, def_idx), DefPropTag(def_rel_tag)))
+        Ok(PropId(
+            if persistent {
+                DefId::new_persistent(domain_idx, def_tag)
+            } else {
+                DefId::new_transient(domain_idx, def_tag)
+            },
+            DefPropTag(def_rel_tag),
+        ))
     }
 }
 
@@ -280,12 +386,22 @@ pub type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
+    use ontol_core::tag::TagFlags;
+
     use crate::{DefId, DomainIndex};
 
     use super::DefIdSet;
 
-    fn def(i: u16) -> DefId {
-        DefId(DomainIndex::ontol(), i)
+    /// persistent
+    fn pe_def(i: u16) -> DefId {
+        DefId::new_persistent(DomainIndex::ontol(), i)
+    }
+
+    /// transient
+    fn tr_def(i: u16) -> DefId {
+        DefId::new_transient(DomainIndex::ontol(), i)
     }
 
     #[test]
@@ -293,36 +409,66 @@ mod tests {
         let mut set = DefIdSet::default();
         assert_eq!(0, set.len());
 
-        set.insert(def(42));
+        set.insert(pe_def(42));
         assert_eq!(1, set.len());
 
-        set.insert(def(42));
+        set.insert(pe_def(42));
         assert_eq!(1, set.len());
 
-        set.insert(def(40));
+        set.insert(pe_def(40));
         assert_eq!(2, set.len());
 
-        set.insert(def(40));
+        set.insert(pe_def(40));
         assert_eq!(2, set.len());
 
-        set.insert(def(41));
+        set.insert(pe_def(41));
         assert_eq!(3, set.len());
     }
 
     #[test]
     fn def_id_set_from_iterator() {
-        let mut set = DefIdSet::from_iter([def(10), def(5), def(15)]);
+        let mut set = DefIdSet::from_iter([pe_def(10), pe_def(5), pe_def(15)]);
 
-        set.insert(def(5));
+        set.insert(pe_def(5));
         assert_eq!(3, set.len());
 
-        set.insert(def(10));
+        set.insert(pe_def(10));
         assert_eq!(3, set.len());
 
-        set.insert(def(15));
+        set.insert(pe_def(15));
         assert_eq!(3, set.len());
 
-        set.insert(def(20));
+        set.insert(pe_def(20));
         assert_eq!(4, set.len());
+
+        set.insert(pe_def(20));
+        assert_eq!(4, set.len());
+
+        set.insert(tr_def(20));
+        assert_eq!(5, set.len());
+
+        set.insert(tr_def(20));
+        assert_eq!(5, set.len());
+    }
+
+    #[test]
+    fn def_id_from_str() {
+        let a = DefId::from_str("def@1:1").unwrap();
+        assert!(a.is_persistent());
+        assert_eq!(
+            a,
+            DefId::new_persistent(DomainIndex::from_u16_and_mask(1, TagFlags::PKG_MASK), 1)
+        );
+        assert_eq!(a.domain_index().index(), 1);
+
+        let b = DefId::from_str("def~1:1").unwrap();
+        assert!(!b.is_persistent());
+        assert_eq!(
+            b,
+            DefId::new_transient(DomainIndex::from_u16_and_mask(1, TagFlags::PKG_MASK), 1)
+        );
+        assert_eq!(b.domain_index().index(), 1);
+
+        assert_ne!(a, b);
     }
 }

--- a/ontol/ontol-runtime/src/ontology.rs
+++ b/ontol/ontol-runtime/src/ontology.rs
@@ -86,7 +86,7 @@ impl Ontology {
     }
 
     pub fn get_def(&self, def_id: DefId) -> Option<&Def> {
-        match self.domain_by_index(def_id.0) {
+        match self.domain_by_index(def_id.domain_index()) {
             Some(domain) => domain.def_option(def_id),
             None => None,
         }

--- a/ontol/ontol-runtime/src/ontology/aspects.rs
+++ b/ontol/ontol-runtime/src/ontology/aspects.rs
@@ -71,23 +71,23 @@ impl DefsAspect {
     }
 
     pub fn def(&self, def_id: DefId) -> &Def {
-        match self.domain_by_index(def_id.0) {
+        match self.domain_by_index(def_id.domain_index()) {
             Some(domain) => domain.def(def_id),
             None => {
-                panic!("No domain for {:?}", def_id.0)
+                panic!("No domain for {:?}", def_id.domain_index())
             }
         }
     }
 
     pub fn get_def(&self, def_id: DefId) -> Option<&Def> {
-        match self.domain_by_index(def_id.0) {
+        match self.domain_by_index(def_id.domain_index()) {
             Some(domain) => domain.def_option(def_id),
             None => None,
         }
     }
 
     pub fn find_edge(&self, id: DefId) -> Option<&EdgeInfo> {
-        let domain = self.domain_by_index(id.0)?;
+        let domain = self.domain_by_index(id.domain_index())?;
         domain.find_edge(id)
     }
 

--- a/ontol/ontol-runtime/src/sequence.rs
+++ b/ontol/ontol-runtime/src/sequence.rs
@@ -420,7 +420,7 @@ mod tests {
     }
 
     fn def(id: u16) -> ValueTag {
-        DefId(DomainIndex::from_u16_and_mask(1337, TagFlags::PKG_MASK), id).into()
+        DefId::new_persistent(DomainIndex::from_u16_and_mask(1337, TagFlags::PKG_MASK), id).into()
     }
 
     fn text(t: &str) -> Value {
@@ -431,7 +431,10 @@ mod tests {
         let attrs = iter.into_iter().map(|(tag, val)| {
             (
                 PropId(
-                    DefId(DomainIndex::from_u16_and_mask(42, TagFlags::PKG_MASK), 42),
+                    DefId::new_persistent(
+                        DomainIndex::from_u16_and_mask(42, TagFlags::PKG_MASK),
+                        42,
+                    ),
                     DefPropTag(tag),
                 ),
                 Attr::Unit(val),
@@ -452,7 +455,10 @@ mod tests {
 
                     (
                         PropId(
-                            DefId(DomainIndex::from_u16_and_mask(42, TagFlags::PKG_MASK), 42),
+                            DefId::new_persistent(
+                                DomainIndex::from_u16_and_mask(42, TagFlags::PKG_MASK),
+                                42,
+                            ),
                             DefPropTag(tag),
                         ),
                         Attr::Unit(value),

--- a/ontol/ontol-runtime/src/vm/ontol_vm.rs
+++ b/ontol/ontol-runtime/src/vm/ontol_vm.rs
@@ -684,7 +684,7 @@ mod tests {
     use super::*;
 
     fn def_id(n: u16) -> DefId {
-        DefId(DomainIndex::ontol(), n)
+        DefId::new_persistent(DomainIndex::ontol(), n)
     }
 
     #[test]

--- a/ontol/ontol-test-utils/src/def_binding.rs
+++ b/ontol/ontol-test-utils/src/def_binding.rs
@@ -125,7 +125,16 @@ impl<'on> DefBinding<'on> {
             .domain_by_index(self.def.id.domain_index())
             .unwrap();
 
-        format!("{}:{}", domain.domain_id().id, self.def.id.1)
+        format!(
+            "{}{}:{}",
+            if self.def_id().is_persistent() {
+                ""
+            } else {
+                "~"
+            },
+            domain.domain_id().id,
+            self.def.id.tag()
+        )
     }
 
     #[track_caller]


### PR DESCRIPTION
With ontol-log comes the need to distinguish between persistent and transient definitions. Persistent definitions have a stable numeric tag in its DefId, while transient definitions don't. They use different counters. Work-in-progress.